### PR TITLE
Clean up paths

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,4 @@
 omit =
     bam_masterdata/_version.py
     */__init__.py
+    bam_masterdata/datamodel/*.py

--- a/bam_masterdata/cli/cli.py
+++ b/bam_masterdata/cli/cli.py
@@ -24,42 +24,18 @@ from bam_masterdata.utils import (
 
 def find_datamodel_dir():
     """Search for 'datamodel/' in possible locations and return its absolute path."""
-    # Get current working directory
-    cwd = Path.cwd()
-
-    # Get the script's directory (relevant for installed packages)
-    script_dir = Path(__file__).parent
-
-    # Get the root of the repository if running inside one
-    possible_roots = [cwd, script_dir]
-
-    # If running inside a package, check sys.path for possible project locations
-    for path in sys.path:
-        if "/usr/" in path:
-            continue
-        possible_roots.append(Path(path))
-
-    possible_locations = set()
-
-    for root in possible_roots:
-        possible_locations.update(
-            [
-                root / "datamodel",  # Directly in the project root
-                root / "bam_masterdata" / "datamodel",  # Inside bam_masterdata
-                root
-                / "src"
-                / "bam_masterdata"
-                / "datamodel",  # Inside src-based structure
-                *(
-                    p / "datamodel" for p in root.iterdir() if p.is_dir()
-                ),  # Any other package/datamodel structures
-            ]
-        )
+    possible_locations = [
+        # Case: Running from a project with `datamodel/`
+        Path.cwd() / "datamodel",
+        # Case: Running inside bam-masterdata
+        Path.cwd() / "bam_masterdata" / "datamodel",
+        # Case: Running inside installed package
+        Path(__file__).parent / "datamodel",
+    ]
 
     for path in possible_locations:
         if path.exists():
             return str(path.resolve())
-
     raise FileNotFoundError("Could not find a valid 'datamodel/' directory.")
 
 

--- a/bam_masterdata/cli/cli.py
+++ b/bam_masterdata/cli/cli.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import sys
 import time
 from pathlib import Path
 
@@ -36,6 +35,7 @@ def find_datamodel_dir():
     for path in possible_locations:
         if path.exists():
             return str(path.resolve())
+
     raise FileNotFoundError("Could not find a valid 'datamodel/' directory.")
 
 


### PR DESCRIPTION
This pull request includes several changes to the `bam_masterdata/cli/cli.py` file, focusing on adding new options for export directories and improving the robustness of the export functions. The most important changes include adding the `--export-dir` option to various export functions and ensuring user confirmation before deleting directories.

Enhancements to export functions:

* Added the `--export-dir` option to the `export_to_json`, `export_to_excel`, and `export_to_rdf` functions, allowing users to specify the directory where files will be exported. The default directory is `./artifacts`. [[1]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L154-R167) [[2]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L204-R226) [[3]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L275-R306)
* Added a confirmation prompt to ensure users want to delete the specified export directory before proceeding with the deletion in the `export_to_json`, `export_to_excel`, and `export_to_rdf` functions. [[1]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L154-R167) [[2]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L204-R226) [[3]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L275-R306)