### PR TITLE
Fix export to excel

### DIFF
--- a/bam_masterdata/cli/cli.py
+++ b/bam_masterdata/cli/cli.py
@@ -68,13 +68,22 @@ def cli():
     (Optional) The path to the Masterdata Excel file.
     """,
 )
-def fill_masterdata(url, excel_file):
+@click.option(
+    "--export-dir",
+    type=str,
+    required=False,
+    help="The directory where the Masterdata will be exported to.",
+)
+def fill_masterdata(url, excel_file, export_dir):
     start_time = time.time()
 
     # Define output directory
-    output_directory = (
-        os.path.join(DATAMODEL_DIR, "tmp") if excel_file else DATAMODEL_DIR
-    )
+    if export_dir is not None:
+        output_directory = export_dir
+    else:
+        output_directory = (
+            os.path.join(DATAMODEL_DIR, "tmp") if excel_file else DATAMODEL_DIR
+        )
 
     # Ensure the output directory exists
     os.makedirs(output_directory, exist_ok=True)
@@ -148,7 +157,7 @@ def fill_masterdata(url, excel_file):
     default=DATAMODEL_DIR,
     help="""
     (Optional) The path to the individual Python module or the directory containing the Python modules to process the datamodel.
-    Default is `./bam_masterdata/datamodel/`.
+    Default is the `/datamodel/` directory.
     """,
 )
 @click.option(
@@ -179,7 +188,7 @@ def export_to_json(force_delete, python_path, export_dir):
         if module_path.endswith("property_types.py"):
             if duplicated_property_types(module_path=module_path, logger=logger):
                 click.echo(
-                    "Please fix the duplicated property types before exporting to RDF/XML."
+                    "Please fix the duplicated property types before exporting to JSON."
                 )
                 return
         entities_to_json(module_path=module_path, export_dir=export_dir, logger=logger)
@@ -207,7 +216,7 @@ def export_to_json(force_delete, python_path, export_dir):
     default=DATAMODEL_DIR,
     help="""
     (Optional) The path to the individual Python module or the directory containing the Python modules to process the datamodel.
-    Default is `./bam_masterdata/datamodel/`.
+    Default is the `/datamodel/` directory.
     """,
 )
 @click.option(
@@ -244,7 +253,7 @@ def export_to_excel(force_delete, python_path, export_dir):
         if module_path.endswith("property_types.py"):
             if duplicated_property_types(module_path=module_path, logger=logger):
                 click.echo(
-                    "Please fix the duplicated property types before exporting to RDF/XML."
+                    "Please fix the duplicated property types before exporting to Excel."
                 )
                 return
         if i == 0:

--- a/bam_masterdata/cli/entities_to_excel.py
+++ b/bam_masterdata/cli/entities_to_excel.py
@@ -36,15 +36,17 @@ def entities_to_excel(
             worksheet.append([obj.excel_name])
 
             # Entity header definitions and values
-            worksheet.append(obj.excel_headers)
-            row = []
-            for f_set in obj.model_fields.keys():
-                if f_set == "data_type":
+            excel_headers = []
+            row_values = []
+            for field, excel_header in obj.excel_headers_map.items():
+                if field == "data_type":
                     val = obj.data_type.value
                 else:
-                    val = getattr(obj, f_set)
-                row.append(val)
-            worksheet.append(row)
+                    val = getattr(obj, field)
+                row_values.append(val)
+                excel_headers.append(excel_header)
+            worksheet.append(excel_headers)
+            worksheet.append(row_values)
             worksheet.append([""])  # empty row after entity definitions
         return None
 
@@ -64,34 +66,39 @@ def entities_to_excel(
         for def_name, def_cls in def_members:
             if def_name == obj_definitions.name:
                 break
-        worksheet.append(obj_definitions.excel_headers)
-        header_values = [
-            getattr(obj_definitions, f_set) for f_set in def_cls.model_fields.keys()
-        ]
+        # Appending headers and values in worksheet
+        excel_headers = []
+        header_values = []
+        for field, excel_header in obj_definitions.excel_headers_map.items():
+            header_values.append(getattr(obj_definitions, field))
+            excel_headers.append(excel_header)
+        worksheet.append(excel_headers)
         worksheet.append(header_values)
 
         # Properties assignment for ObjectType, DatasetType, and CollectionType
         if obj_instance.cls_name in ["ObjectType", "DatasetType", "CollectionType"]:
             if not obj_instance.properties:
                 continue
-            worksheet.append(obj_instance.properties[0].excel_headers)
+            worksheet.append(
+                list(obj_instance.properties[0].excel_headers_map.values())
+            )
             for prop in obj_instance.properties:
                 row = []
-                for f_set in prop.model_fields.keys():
-                    if f_set == "data_type":
+                for field in prop.excel_headers_map.keys():
+                    if field == "data_type":
                         val = prop.data_type.value
                     else:
-                        val = getattr(prop, f_set)
+                        val = getattr(prop, field)
                     row.append(val)
                 worksheet.append(row)
         # Terms assignment for VocabularyType
         elif obj_instance.cls_name == "VocabularyType":
             if not obj_instance.terms:
                 continue
-            worksheet.append(obj_instance.terms[0].excel_headers)
+            worksheet.append(list(obj_instance.terms[0].excel_headers_map.values()))
             for term in obj_instance.terms:
                 worksheet.append(
-                    getattr(term, f_set) for f_set in term.model_fields.keys()
+                    getattr(term, f_set) for f_set in term.excel_headers_map.keys()
                 )
 
         # ? do the PropertyTypeDef need to be exported to Excel?

--- a/bam_masterdata/metadata/definitions.py
+++ b/bam_masterdata/metadata/definitions.py
@@ -121,15 +121,15 @@ class EntityDef(BaseModel):
         return name_map.get(self.name)
 
     @property
-    def excel_headers(self) -> list[str]:
+    def excel_headers_map(self) -> dict:
         """
-        Returns the headers for the entity in a format suitable for the openBIS Excel file.
+        Maps the field keys of the Pydantic model into the openBIS Excel style headers.
         """
-        return [
-            k.capitalize().replace("_", " ")
-            for k in self.model_fields.keys()
-            if k != "id"
-        ]
+        fields = [k for k in self.model_fields.keys() if k != "id"]
+        headers: dict = {}
+        for f in fields:
+            headers[f] = f.replace("_", " ").capitalize()
+        return headers
 
     @model_validator(mode="after")
     @classmethod


### PR DESCRIPTION
This pull request includes changes to the `bam_masterdata` CLI tool to enhance its functionality and improve code readability. The most important changes include adding an option for specifying the export directory in the `fill_masterdata` function, updating help messages, and refactoring the `entities_to_excel` function to use a dictionary for Excel headers.

Enhancements to CLI functionality:

* [`bam_masterdata/cli/cli.py`](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L71-R83): Added an optional `--export-dir` parameter to the `fill_masterdata` function to specify the directory where the Masterdata will be exported.

Updates to help messages:

* [`bam_masterdata/cli/cli.py`](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L151-R160): Updated the default path in the help message for the `datamodel` option to `/datamodel/` instead of `./bam_masterdata/datamodel/`. [[1]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L151-R160) [[2]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L210-R219)

Refactoring for code readability:

* [`bam_masterdata/cli/entities_to_excel.py`](diffhunk://#diff-57510029e91d2bb847ef7bbe78767d5b4616182ad3d6ea58909d4e5c5a7072d0L39-R49): Refactored the `entities_to_excel` function to use a dictionary (`excel_headers_map`) for mapping field keys to Excel headers, improving code readability and maintainability. [[1]](diffhunk://#diff-57510029e91d2bb847ef7bbe78767d5b4616182ad3d6ea58909d4e5c5a7072d0L39-R49) [[2]](diffhunk://#diff-57510029e91d2bb847ef7bbe78767d5b4616182ad3d6ea58909d4e5c5a7072d0L67-R101)
* [`bam_masterdata/metadata/definitions.py`](diffhunk://#diff-2932caf9fee85eb8a9c3b6c4c9b3116686cdeca6cc3ccb74a51ef9f093e4b6d9L124-R132): Changed the `excel_headers` property to `excel_headers_map`, which returns a dictionary mapping field keys to Excel headers.