### PR TITLE
Add row cell information to fill-masterdata from excel

### DIFF
--- a/bam_masterdata/cli/cli.py
+++ b/bam_masterdata/cli/cli.py
@@ -74,7 +74,17 @@ def cli():
     required=False,
     help="The directory where the Masterdata will be exported to.",
 )
-def fill_masterdata(url, excel_file, export_dir):
+@click.option(
+    "--row-cell-info",
+    type=bool,
+    required=False,
+    default=False,
+    help="""
+    (Optional) If when exporting the masterdata from the Excel file, the information of which row in the Excel
+    each field is defined should be stored (useful for the `checker` CLI).
+    """,
+)
+def fill_masterdata(url, excel_file, export_dir, row_cell_info):
     start_time = time.time()
 
     # Define output directory
@@ -98,7 +108,11 @@ def fill_masterdata(url, excel_file, export_dir):
     # Use the URL if provided, otherwise fall back to defaults
     if excel_file:
         click.echo(f"Using the Masterdata Excel file path: {excel_file}\n")
-        generator = MasterdataCodeGenerator(path=excel_file)
+        if row_cell_info:
+            click.echo("Cell information will be stored in the Python fields.")
+        generator = MasterdataCodeGenerator(
+            path=excel_file, row_cell_info=row_cell_info
+        )
     else:
         if not url:
             url = environ("OPENBIS_URL")

--- a/bam_masterdata/cli/fill_masterdata.py
+++ b/bam_masterdata/cli/fill_masterdata.py
@@ -13,8 +13,9 @@ class MasterdataCodeGenerator:
     openBIS instance.
     """
 
-    def __init__(self, url: str = "", path: str = ""):
+    def __init__(self, url: str = "", path: str = "", **kwargs):
         start_time = time.time()
+        self.row_cell_info = kwargs.get("row_cell_info", False)
         # * This part takes some time due to the loading of all entities from Openbis
         if url:
             self.properties = OpenbisEntities(url=url).get_property_dict()
@@ -28,13 +29,13 @@ class MasterdataCodeGenerator:
             )
         else:
             entities_dict = MasterdataExcelExtractor(
-                excel_path=path
+                excel_path=path, row_cell_info=self.row_cell_info
             ).excel_to_entities()
-            self.properties = entities_dict["property_types"]
-            self.collections = entities_dict["collection_types"]
-            self.datasets = entities_dict["dataset_types"]
-            self.objects = entities_dict["object_types"]
-            self.vocabularies = entities_dict["vocabulary_types"]
+            self.properties = entities_dict.get("property_types", {})
+            self.collections = entities_dict.get("collection_types", {})
+            self.datasets = entities_dict.get("dataset_types", {})
+            self.objects = entities_dict.get("object_types", {})
+            self.vocabularies = entities_dict.get("vocabulary_types", {})
             elapsed_time = time.time() - start_time
             click.echo(
                 f"Loaded Masterdata excel entities in `MasterdataCodeGenerator` initialization {elapsed_time:.2f} seconds\n"

--- a/bam_masterdata/logger.py
+++ b/bam_masterdata/logger.py
@@ -25,13 +25,14 @@ structlog.configure(
     processors=[
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.add_log_level,
-        structlog.processors.CallsiteParameterAdder(
-            [
-                structlog.processors.CallsiteParameter.PATHNAME,
-                structlog.processors.CallsiteParameter.FUNC_NAME,
-                structlog.processors.CallsiteParameter.LINENO,
-            ]
-        ),
+        # ! commented out as this is not very useful when debugging with VSCode
+        # structlog.processors.CallsiteParameterAdder(
+        #     [
+        #         structlog.processors.CallsiteParameter.PATHNAME,
+        #         structlog.processors.CallsiteParameter.FUNC_NAME,
+        #         structlog.processors.CallsiteParameter.LINENO,
+        #     ]
+        # ),
         store_log_message,
         structlog.dev.ConsoleRenderer(),
     ],

--- a/bam_masterdata/metadata/definitions.py
+++ b/bam_masterdata/metadata/definitions.py
@@ -84,6 +84,15 @@ class EntityDef(BaseModel):
         """,
     )
 
+    row_location: Optional[str] = Field(
+        default=None,
+        description="""
+        Row in the Excel at which the entity type field is defined. It is a string with the format `"<row-letter><row_number>"`.
+        Example: "A1" ot "A107". This field is useful when checking the consistency of Excel files with multiple entity
+        types defined to quickly locate the specific Excel cell which logs a message when applying the `checker` CLI.
+        """,
+    )
+
     # TODO check ontology_id, ontology_version, ontology_annotation_id, internal (found in the openBIS docu)
 
     @field_validator("code")
@@ -125,7 +134,9 @@ class EntityDef(BaseModel):
         """
         Maps the field keys of the Pydantic model into the openBIS Excel style headers.
         """
-        fields = [k for k in self.model_fields.keys() if k != "id"]
+        fields = [
+            k for k in self.model_fields.keys() if k not in ["id", "row_location"]
+        ]
         headers: dict = {}
         for f in fields:
             headers[f] = f.replace("_", " ").capitalize()


### PR DESCRIPTION
@carlosmada22 be aware of this, I've made a couple of minor changes. Please, have a look 🙂 

This pull request introduces a new feature to track the row location of fields in the Excel file when exporting master data. It also includes several enhancements to error logging for better debugging and consistency checking. The most important changes include adding a new CLI option, modifying the `MasterdataCodeGenerator` and `MasterdataExcelExtractor` classes to handle the new option, and updating error logging to include more contextual information.

Enhancements to CLI and data processing:

* [`bam_masterdata/cli/cli.py`](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L77-R87): Added a new CLI option `--row-cell-info` to the `fill_masterdata` function to optionally store information about the row location of each field in the Excel file. [[1]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L77-R87) [[2]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L101-R115)

Modifications to data extraction:

* [`bam_masterdata/cli/fill_masterdata.py`](diffhunk://#diff-7348b5d5d645b7711563e3f802d6bba9ad4105c6bed7cc58f5c840b2a18bc0e4L16-R18): Updated the `MasterdataCodeGenerator` class to accept the `row_cell_info` parameter and pass it to the `MasterdataExcelExtractor`. [[1]](diffhunk://#diff-7348b5d5d645b7711563e3f802d6bba9ad4105c6bed7cc58f5c840b2a18bc0e4L16-R18) [[2]](diffhunk://#diff-7348b5d5d645b7711563e3f802d6bba9ad4105c6bed7cc58f5c840b2a18bc0e4L31-R38)
* [`bam_masterdata/excel/excel_to_entities.py`](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL21-R26): Enhanced the `MasterdataExcelExtractor` class to store row location information if the `row_cell_info` parameter is set. Updated methods to include this information in the extracted data. [[1]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL21-R26) [[2]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dR466-R467) [[3]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL425-R495) [[4]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dR510-R513) [[5]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL577-R642)

Improvements to error logging:

* [`bam_masterdata/excel/excel_to_entities.py`](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL148-R153): Enhanced error logging to include additional contextual information such as term, cell value, cell coordinate, and sheet title. [[1]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL148-R153) [[2]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL183-R233) [[3]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL286-R323) [[4]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL316-R353) [[5]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL340-R381) [[6]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL351-R398) [[7]](diffhunk://#diff-f38b39218efbb34858c77646e45bf29382760f8b309273733fa51b3598d3119dL373-R430)

Additional changes:

* [`bam_masterdata/logger.py`](diffhunk://#diff-9263ffeb67353505e51138aafb81004667e3f7f9340c5bd35d0cf2fd256754bdL28-R35): Commented out the `CallsiteParameterAdder` in the logger configuration to improve debugging with VSCode.
* [`bam_masterdata/metadata/definitions.py`](diffhunk://#diff-2932caf9fee85eb8a9c3b6c4c9b3116686cdeca6cc3ccb74a51ef9f093e4b6d9R87-R95): Added a new optional field `row_location` to the `EntityDef` class to store the row location of each entity type field. Updated the `excel_headers_map` method to exclude this field from the headers. [[1]](diffhunk://#diff-2932caf9fee85eb8a9c3b6c4c9b3116686cdeca6cc3ccb74a51ef9f093e4b6d9R87-R95) [[2]](diffhunk://#diff-2932caf9fee85eb8a9c3b6c4c9b3116686cdeca6cc3ccb74a51ef9f093e4b6d9L128-R139)