### PR TITLE
108 checker for individual dsst repos

### DIFF
--- a/bam_masterdata/checker/masterdata_validator.py
+++ b/bam_masterdata/checker/masterdata_validator.py
@@ -59,7 +59,7 @@ class MasterDataValidator:
 
         if mode in ["compare", "all"]:
             self.logger.info("Comparing new entities with current model...")
-            self._compare_with_current_model()
+            self._compare_with_current_model(mode=mode)
             self._extract_log_messages(
                 self.new_entities, self.validation_results["comparisons"]
             )

--- a/bam_masterdata/checker/masterdata_validator.py
+++ b/bam_masterdata/checker/masterdata_validator.py
@@ -64,6 +64,23 @@ class MasterDataValidator:
                 self.new_entities, self.validation_results["comparisons"]
             )
 
+        if mode == "individual":
+            self.logger.info(
+                "Validating new DSST entities and comparing them with current model..."
+            )
+            self.validation_results = {
+                "incoming_model": {},
+                "comparisons": {},
+            }
+            self._validate_model(self.new_entities)
+            self._extract_log_messages(
+                self.new_entities, self.validation_results["incoming_model"]
+            )
+            self._compare_with_current_model(mode="individual")
+            self._extract_log_messages(
+                self.new_entities, self.validation_results["comparisons"]
+            )
+
         return self.validation_results
 
     def _validate_model(self, model: dict) -> dict:
@@ -290,7 +307,7 @@ class MasterDataValidator:
                         level="error",
                     )
 
-    def _compare_with_current_model(self) -> dict:
+    def _compare_with_current_model(self, mode) -> dict:
         """
         Compare new entities against the current model using validation rules.
         """
@@ -313,6 +330,11 @@ class MasterDataValidator:
                     incoming_entity["_log_msgs"] = []
 
                 if current_entity:
+                    if mode == "individual":
+                        log_message = f"The entity {entity_code} already exists in `bam-masterdata`. Please, check your classes. "
+                        self._store_log_message(
+                            incoming_entity, log_message, level="critical"
+                        )
                     # Compare general attributes for all entities
                     for key, new_value in incoming_entity.get("defs", {}).items():
                         incoming_row_location = incoming_entity.get("defs", {}).get(


### PR DESCRIPTION
### In individual DSSt repos
- [x] Create CLI `check` which accepts:
    - [x] `--excel-file` (same behavior as in `import-from-excel`):
    - [x] `--python-path`:
        - [x] individual Python modules
        - [x] directory with all Python modules to be checked
- [x] Reads all entity types. Reads all `bam-masterdata` entity types.
- [x] For each entity type:
    - [x] Stores all logger inside each entity under a field `_log_msgs` list of strings
    - [x] If `cls_name` exists in bam-masterdata: ```logger.critical(f"The entity {cls_name} already exists in `bam-masterdata`. Please, check your classes.")```
    - [x] Else: pass
- [x] When this is done, apply same `check` w.r.t. openBIS as [in bam-masterdata](#in-bam-masterdata)