### PR TITLE
Add iri to field of EntityDef

### DIFF
--- a/bam_masterdata/checker/source_loader.py
+++ b/bam_masterdata/checker/source_loader.py
@@ -73,6 +73,7 @@ class SourceLoader:
                         "row_location": entity_data.get("row_location"),
                         "validation_script": entity_data.get("validationPlugin")
                         or None,  # Convert "" to None
+                        "iri": entity_data.get("iri") or None,  # Convert "" to None
                     },
                 }
 
@@ -104,6 +105,7 @@ class SourceLoader:
                                 prop_name
                             ),  # Now correctly formatted to PascalCase
                             "row_location": prop_data.get("row_location"),
+                            "iri": prop_data.get("iri") or None,  # Convert "" to None
                             "property_label": prop_data.get("label"),
                             "data_type": prop_data.get("dataType"),
                             "vocabulary_code": prop_data.get("vocabularyCode")

--- a/bam_masterdata/metadata/definitions.py
+++ b/bam_masterdata/metadata/definitions.py
@@ -118,8 +118,10 @@ class EntityDef(BaseModel):
 
     @field_validator("iri")
     @classmethod
-    def validate_iri(cls, value: str) -> str:
-        if not value or not re.match(
+    def validate_iri(cls, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return value
+        if not re.match(
             r"^http://purl.obolibrary.org/bam-masterdata/[\w_]+:[\d.]+$", value
         ):
             raise ValueError(

--- a/bam_masterdata/metadata/definitions.py
+++ b/bam_masterdata/metadata/definitions.py
@@ -76,6 +76,16 @@ class EntityDef(BaseModel):
         """,
     )
 
+    # TODO: check if it is necessary to add something like `ontology_annotation_id` in the future
+    iri: Optional[str] = Field(
+        default=None,
+        description="""
+        IRI (Internationalized Resource Identifier) of the entity. This is a unique identifier for the entity
+        and is used to link the entity to an ontology. It is a string with the format `"<ontology_id>:<ontology_version>"`.
+        Example: "http://purl.obolibrary.org/bam-masterdata/Instrument:1.0.0".
+        """,
+    )
+
     id: Optional[str] = Field(
         default=None,
         description="""
@@ -103,6 +113,19 @@ class EntityDef(BaseModel):
                 "`code` must follow the rules specified in the description: 1) Must be uppercase, "
                 "2) separated by underscores, 3) start with a dollar sign if native to openBIS, "
                 "4) separated by dots if there is inheritance."
+            )
+        return value
+
+    @field_validator("iri")
+    @classmethod
+    def validate_iri(cls, value: str) -> str:
+        if not value or not re.match(
+            r"^http://purl.obolibrary.org/bam-masterdata/[\w_]+:[\d.]+$", value
+        ):
+            raise ValueError(
+                "`iri` must follow the rules specified in the description: 1) Must start with 'http://purl.obolibrary.org/bam-masterdata/', "
+                "2) followed by the entity name, 3) separated by a colon, 4) followed by the semantic versioning number. "
+                "Example: 'http://purl.obolibrary.org/bam-masterdata/Instrument:1.0.0'."
             )
         return value
 
@@ -135,7 +158,9 @@ class EntityDef(BaseModel):
         Maps the field keys of the Pydantic model into the openBIS Excel style headers.
         """
         fields = [
-            k for k in self.model_fields.keys() if k not in ["id", "row_location"]
+            k
+            for k in self.model_fields.keys()
+            if k not in ["iri", "id", "row_location"]
         ]
         headers: dict = {}
         for f in fields:

--- a/tests/checker/test_source_loader.py
+++ b/tests/checker/test_source_loader.py
@@ -1,5 +1,4 @@
-import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -37,6 +36,7 @@ def expected_transformed_data():
                     {
                         "code": "$NAME",
                         "description": "Name",
+                        "iri": None,
                         "id": "Name",
                         "property_label": "Name",
                         "data_type": "VARCHAR",
@@ -54,6 +54,7 @@ def expected_transformed_data():
                 "defs": {
                     "code": "COLLECTION",
                     "description": "",
+                    "iri": None,
                     "id": "Collection",
                     "validation_script": None,
                 },
@@ -63,6 +64,7 @@ def expected_transformed_data():
                     {
                         "code": "DEFAULT_EXPERIMENT.EXPERIMENTAL_DESCRIPTION",
                         "description": "Description of the experiment",
+                        "iri": None,
                         "id": "DefaultExperimentExperimentalDescription",
                         "property_label": "Description",
                         "data_type": "MULTILINE_VARCHAR",
@@ -80,6 +82,7 @@ def expected_transformed_data():
                 "defs": {
                     "code": "DEFAULT_EXPERIMENT",
                     "description": "",
+                    "iri": None,
                     "id": "DefaultExperiment",
                     "validation_script": "DEFAULT_EXPERIMENT.date_range_validation",
                 },
@@ -91,6 +94,7 @@ def expected_transformed_data():
                     {
                         "code": "$HISTORY_ID",
                         "description": "History ID",
+                        "iri": None,
                         "id": "HistoryId",
                         "property_label": "History ID",
                         "data_type": "VARCHAR",
@@ -108,6 +112,7 @@ def expected_transformed_data():
                 "defs": {
                     "code": "ANALYSIS_NOTEBOOK",
                     "description": "",
+                    "iri": None,
                     "id": "AnalysisNotebook",
                     "validation_script": None,
                     "main_dataset_pattern": None,
@@ -119,6 +124,7 @@ def expected_transformed_data():
                     {
                         "code": "NOTES",
                         "description": "Notes//Notizen",
+                        "iri": None,
                         "id": "Notes",
                         "property_label": "Notes",
                         "data_type": "MULTILINE_VARCHAR",
@@ -136,6 +142,7 @@ def expected_transformed_data():
                 "defs": {
                     "code": "ANALYZED_DATA",
                     "description": "",
+                    "iri": None,
                     "id": "AnalyzedData",
                     "validation_script": None,
                     "main_dataset_pattern": None,
@@ -149,6 +156,7 @@ def expected_transformed_data():
                     {
                         "code": "ACTING_PERSON",
                         "description": "Acting Person//Handelnde Person",
+                        "iri": None,
                         "id": "ActingPerson",
                         "property_label": "Acting Person",
                         "data_type": "OBJECT",
@@ -166,6 +174,7 @@ def expected_transformed_data():
                 "defs": {
                     "code": "ACTION",
                     "description": "This Object allows to store information on an action by a user.//Dieses Objekt erlaubt eine Nutzer-Aktion zu beschreiben.",
+                    "iri": None,
                     "id": "Action",
                     "validation_script": None,
                     "generated_code_prefix": "ACT",

--- a/tests/metadata/test_definitions.py
+++ b/tests/metadata/test_definitions.py
@@ -50,8 +50,8 @@ class TestEntityDef:
         """Test the existing defined fields of the `EntityDef` class."""
         names = list(EntityDef.model_fields.keys())
         field_types = [val.annotation for val in list(EntityDef.model_fields.values())]
-        assert names == ["code", "description", "id", "row_location"]
-        assert field_types == [str, str, Optional[str], Optional[str]]
+        assert names == ["code", "description", "iri", "id", "row_location"]
+        assert field_types == [str, str, Optional[str], Optional[str], Optional[str]]
 
     @pytest.mark.parametrize(
         "code, description, id, is_valid",
@@ -123,11 +123,19 @@ class TestBaseObjectTypeDef:
         assert names == [
             "code",
             "description",
+            "iri",
             "id",
             "row_location",
             "validation_script",
         ]
-        assert field_types == [str, str, Optional[str], Optional[str], Optional[str]]
+        assert field_types == [
+            str,
+            str,
+            Optional[str],
+            Optional[str],
+            Optional[str],
+            Optional[str],
+        ]
 
 
 class TestCollectionTypeDef:
@@ -140,11 +148,19 @@ class TestCollectionTypeDef:
         assert names == [
             "code",
             "description",
+            "iri",
             "id",
             "row_location",
             "validation_script",
         ]
-        assert field_types == [str, str, Optional[str], Optional[str], Optional[str]]
+        assert field_types == [
+            str,
+            str,
+            Optional[str],
+            Optional[str],
+            Optional[str],
+            Optional[str],
+        ]
 
 
 class TestDatasetTypeDef:
@@ -157,6 +173,7 @@ class TestDatasetTypeDef:
         assert names == [
             "code",
             "description",
+            "iri",
             "id",
             "row_location",
             "validation_script",
@@ -166,6 +183,7 @@ class TestDatasetTypeDef:
         assert field_types == [
             str,
             str,
+            Optional[str],
             Optional[str],
             Optional[str],
             Optional[str],
@@ -184,6 +202,7 @@ class TestObjectTypeDef:
         assert names == [
             "code",
             "description",
+            "iri",
             "id",
             "row_location",
             "validation_script",
@@ -193,6 +212,7 @@ class TestObjectTypeDef:
         assert field_types == [
             str,
             str,
+            Optional[str],
             Optional[str],
             Optional[str],
             Optional[str],
@@ -232,6 +252,7 @@ class TestPropertyTypeDef:
         assert names == [
             "code",
             "description",
+            "iri",
             "id",
             "row_location",
             "property_label",
@@ -244,6 +265,7 @@ class TestPropertyTypeDef:
         assert field_types == [
             str,
             str,
+            Optional[str],
             Optional[str],
             Optional[str],
             str,
@@ -265,6 +287,7 @@ class TestPropertyTypeAssignment:
         assert names == [
             "code",
             "description",
+            "iri",
             "id",
             "row_location",
             "property_label",
@@ -282,6 +305,7 @@ class TestPropertyTypeAssignment:
         assert field_types == [
             str,
             str,
+            Optional[str],
             Optional[str],
             Optional[str],
             str,
@@ -305,8 +329,22 @@ class TestVocabularyTypeDef:
         field_types = [
             val.annotation for val in list(VocabularyTypeDef.model_fields.values())
         ]
-        assert names == ["code", "description", "id", "row_location", "url_template"]
-        assert field_types == [str, str, Optional[str], Optional[str], Optional[str]]
+        assert names == [
+            "code",
+            "description",
+            "iri",
+            "id",
+            "row_location",
+            "url_template",
+        ]
+        assert field_types == [
+            str,
+            str,
+            Optional[str],
+            Optional[str],
+            Optional[str],
+            Optional[str],
+        ]
 
 
 class TestVocabularyTerm:
@@ -319,6 +357,7 @@ class TestVocabularyTerm:
         assert names == [
             "code",
             "description",
+            "iri",
             "id",
             "row_location",
             "url_template",
@@ -328,6 +367,7 @@ class TestVocabularyTerm:
         assert field_types == [
             str,
             str,
+            Optional[str],
             Optional[str],
             Optional[str],
             Optional[str],

--- a/tests/metadata/test_entities.py
+++ b/tests/metadata/test_entities.py
@@ -73,7 +73,7 @@ class TestBaseEntity:
         entity = generate_base_entity()
         assert (
             entity.model_to_json()
-            == '{"defs": {"code": "MOCKED_ENTITY", "description": "Mockup for an entity definition//Mockup f\\u00fcr eine Entit\\u00e4tsdefinition", "id": "MockedEntity", "row_location": null, "validation_script": null, "generated_code_prefix": "MOCKENT", "auto_generated_codes": true}}'
+            == '{"defs": {"code": "MOCKED_ENTITY", "description": "Mockup for an entity definition//Mockup f\\u00fcr eine Entit\\u00e4tsdefinition", "iri": null, "id": "MockedEntity", "row_location": null, "validation_script": null, "generated_code_prefix": "MOCKENT", "auto_generated_codes": true}}'
         )
 
     def test_model_to_dict(self):
@@ -83,6 +83,7 @@ class TestBaseEntity:
             "defs": {
                 "code": "MOCKED_ENTITY",
                 "description": "Mockup for an entity definition//Mockup für eine Entitätsdefinition",
+                "iri": None,
                 "id": "MockedEntity",
                 "row_location": None,
                 "validation_script": None,

--- a/tests/metadata/test_entities_dict.py
+++ b/tests/metadata/test_entities_dict.py
@@ -19,6 +19,7 @@ class TestEntitiesDict:
                         {
                         "code": "$DEFAULT_COLLECTION_VIEW",
                         "description": "Default view for experiments of the type collection",
+                        "iri": null,
                         "id": "DefaultCollectionView",
                         "row_location": 34,
                         "property_label": "Default collection view",
@@ -36,6 +37,7 @@ class TestEntitiesDict:
                         {
                         "code": "$DEFAULT_OBJECT_TYPE",
                         "description": "Enter the code of the object type for which the collection is used",
+                        "iri": null,
                         "id": "DefaultObjectType",
                         "row_location": 24,
                         "property_label": "Default object type",
@@ -53,6 +55,7 @@ class TestEntitiesDict:
                         {
                         "code": "$NAME",
                         "description": "Name",
+                        "iri": null,
                         "id": "Name",
                         "row_location": 14,
                         "property_label": "Name",
@@ -71,6 +74,7 @@ class TestEntitiesDict:
                     "defs": {
                         "code": "COLLECTION",
                         "description": "",
+                        "iri": null,
                         "id": "Collection",
                         "row_location": 8,
                         "validation_script": null
@@ -87,6 +91,7 @@ class TestEntitiesDict:
                         {
                         "code": "ACTING_PERSON",
                         "description": "Acting Person//Handelnde Person",
+                        "iri": null,
                         "id": "ActingPerson",
                         "row_location": 4140,
                         "property_label": "Acting Person",
@@ -104,6 +109,7 @@ class TestEntitiesDict:
                         {
                         "code": "ACTION_DATE",
                         "description": "Action Date//Datum der Handlung",
+                        "iri": null,
                         "id": "ActionDate",
                         "row_location": 4130,
                         "property_label": "Monitoring Date",
@@ -121,6 +127,7 @@ class TestEntitiesDict:
                         {
                         "code": "$ANNOTATIONS_STATE",
                         "description": "Annotations State",
+                        "iri": null,
                         "id": "AnnotationsState",
                         "row_location": 4160,
                         "property_label": "Annotations State",
@@ -138,6 +145,7 @@ class TestEntitiesDict:
                         {
                         "code": "$NAME",
                         "description": "Name",
+                        "iri": null,
                         "id": "Name",
                         "row_location": 4120,
                         "property_label": "Name",
@@ -155,6 +163,7 @@ class TestEntitiesDict:
                         {
                         "code": "$XMLCOMMENTS",
                         "description": "Comments log",
+                        "iri": null,
                         "id": "Xmlcomments",
                         "row_location": 4150,
                         "property_label": "Comments",
@@ -173,6 +182,7 @@ class TestEntitiesDict:
                     "defs": {
                         "code": "ACTION",
                         "description": "This Object allows to store information on an action by a user.//Dieses Objekt erlaubt eine Nutzer-Aktion zu beschreiben.",
+                        "iri": null,
                         "id": "Action",
                         "row_location": 4113,
                         "validation_script": null,
@@ -188,6 +198,7 @@ class TestEntitiesDict:
                 """{
                     "code": "$NAME",
                     "description": "Name",
+                    "iri": null,
                     "id": "Name",
                     "row_location": 60,
                     "property_label": "Name",
@@ -207,6 +218,7 @@ class TestEntitiesDict:
                         {
                         "code": "BDS_DIRECTORY",
                         "description": "",
+                        "iri": null,
                         "id": "BdsDirectory",
                         "row_location": 30,
                         "url_template": null,
@@ -216,6 +228,7 @@ class TestEntitiesDict:
                         {
                         "code": "PROPRIETARY",
                         "description": "",
+                        "iri": null,
                         "id": "Proprietary",
                         "row_location": 36,
                         "url_template": null,
@@ -226,6 +239,7 @@ class TestEntitiesDict:
                     "defs": {
                         "code": "$STORAGE_FORMAT",
                         "description": "The on-disk storage format of a data set",
+                        "iri": null,
                         "id": "StorageFormat",
                         "row_location": 24,
                         "url_template": null


### PR DESCRIPTION
This pull request introduces the addition of the `iri` field to various components in the `bam_masterdata` module, including entity definitions, JSON transformations, and test cases. The most important changes are summarized below:

### Addition of `iri` Field to Entity Definitions

* [`bam_masterdata/metadata/definitions.py`](diffhunk://#diff-2932caf9fee85eb8a9c3b6c4c9b3116686cdeca6cc3ccb74a51ef9f093e4b6d9R79-R88): Added the `iri` field to the `EntityDef` class, including a description and validation rules. [[1]](diffhunk://#diff-2932caf9fee85eb8a9c3b6c4c9b3116686cdeca6cc3ccb74a51ef9f093e4b6d9R79-R88) [[2]](diffhunk://#diff-2932caf9fee85eb8a9c3b6c4c9b3116686cdeca6cc3ccb74a51ef9f093e4b6d9R119-R131)
* [`bam_masterdata/metadata/definitions.py`](diffhunk://#diff-2932caf9fee85eb8a9c3b6c4c9b3116686cdeca6cc3ccb74a51ef9f093e4b6d9L138-R163): Updated the `excel_headers_map` method to exclude the `iri` field from the headers.

### Updates to JSON Transformations

* [`bam_masterdata/checker/source_loader.py`](diffhunk://#diff-60940b1b367b72f70b9568a2a0e6c44d07b4aac1e7d4b2cfff3be80df9b55ebbR76): Added the `iri` field to the JSON output in the `entities_to_json` method. [[1]](diffhunk://#diff-60940b1b367b72f70b9568a2a0e6c44d07b4aac1e7d4b2cfff3be80df9b55ebbR76) [[2]](diffhunk://#diff-60940b1b367b72f70b9568a2a0e6c44d07b4aac1e7d4b2cfff3be80df9b55ebbR108)

### Test Case Modifications

* [`tests/checker/test_source_loader.py`](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R39): Updated the `expected_transformed_data` method to include the `iri` field with a value of `None`. [[1]](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R39) [[2]](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R57) [[3]](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R67) [[4]](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R85) [[5]](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R97) [[6]](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R115) [[7]](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R127) [[8]](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R145) [[9]](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R159) [[10]](diffhunk://#diff-7beb4ab2800be0646ba7826d39bfd5c320583c2871ece6b953b8f5c5a0f940f6R177)
* [`tests/metadata/test_definitions.py`](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aL53-R54): Added the `iri` field to the assertions in the `test_fields` method. [[1]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aL53-R54) [[2]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR126-R138) [[3]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR151-R163) [[4]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR176) [[5]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR191) [[6]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR205) [[7]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR219) [[8]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR255) [[9]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR270) [[10]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR290) [[11]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR310) [[12]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aL308-R347) [[13]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR360) [[14]](diffhunk://#diff-76584bee9566289f3d14a71b07706145003099f4382d2a0aaa3519896412399aR373)
* [`tests/metadata/test_entities.py`](diffhunk://#diff-d7045374535e6171cede2c26a8d9228edf5d9e7167cdf819aa30c06048f8a940L76-R76): Updated the `test_model_to_json` and `test_model_to_dict` methods to include the `iri` field. [[1]](diffhunk://#diff-d7045374535e6171cede2c26a8d9228edf5d9e7167cdf819aa30c06048f8a940L76-R76) [[2]](diffhunk://#diff-d7045374535e6171cede2c26a8d9228edf5d9e7167cdf819aa30c06048f8a940R86)
* [`tests/metadata/test_entities_dict.py`](diffhunk://#diff-f2f877ab1e7dee49d91e579aeed4f489786b7d244038ea5eeaf7cc4fa3d58f5aR22): Added the `iri` field to the entity definitions in the `TestEntitiesDict` class. [[1]](diffhunk://#diff-f2f877ab1e7dee49d91e579aeed4f489786b7d244038ea5eeaf7cc4fa3d58f5aR22) [[2]](diffhunk://#diff-f2f877ab1e7dee49d91e579aeed4f489786b7d244038ea5eeaf7cc4fa3d58f5aR40)