### PR TITLE
Fix find_datamodel_dir

### DIFF
--- a/bam_masterdata/cli/cli.py
+++ b/bam_masterdata/cli/cli.py
@@ -30,7 +30,7 @@ def find_datamodel_dir():
         # Case: Running inside bam-masterdata
         Path.cwd() / "bam_masterdata" / "datamodel",
         # Case: Running inside installed package
-        Path(__file__).parent / "datamodel",
+        Path(__file__).parent.parent / "datamodel",
     ]
 
     for path in possible_locations:


### PR DESCRIPTION
This pull request includes a change to the `find_datamodel_dir` function in the `bam_masterdata/cli/cli.py` file. The change modifies the path to the `datamodel` directory to correctly reference its location when running inside an installed package.

* [`bam_masterdata/cli/cli.py`](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L33-R33): Updated the path to the `datamodel` directory to reference the parent directory of the current file's parent directory instead of just the parent directory.