### PR TITLE
118 fix BAM namespace

### DIFF
--- a/bam_masterdata/cli/entities_to_rdf.py
+++ b/bam_masterdata/cli/entities_to_rdf.py
@@ -11,7 +11,7 @@ from rdflib.namespace import DC, OWL, RDF, RDFS
 
 from bam_masterdata.utils import import_module
 
-BAM = Namespace("https://bamresearch.github.io/bam-masterdata/")
+BAM = Namespace("https://bamresearch.github.io/bam-masterdata/#")
 PROV = Namespace("http://www.w3.org/ns/prov#")
 
 


### PR DESCRIPTION
This pull request includes a change to the `bam_masterdata/cli/entities_to_rdf.py` file. The change updates the namespace URL for the `BAM` variable to include a trailing hash.

* [`bam_masterdata/cli/entities_to_rdf.py`](diffhunk://#diff-c31c6458041f11103669db40a8b1489f89025c70657fd6b1c8c4524d94ff35caL14-R14): Updated the `BAM` namespace URL to "https://bamresearch.github.io/bam-masterdata/#" to include a trailing hash.