### PR TITLE
120 hotfix set in checker

### DIFF
--- a/bam_masterdata/checker/masterdata_validator.py
+++ b/bam_masterdata/checker/masterdata_validator.py
@@ -568,10 +568,10 @@ class MasterdataValidator:
                             codes.add(property_item["code"])
                 # Recursively check for more nested structures
                 elif isinstance(value, (dict, list)):
-                    codes.extend(self.extract_property_codes(value))
+                    codes.update(self.extract_property_codes(value))
 
         elif isinstance(data, list):
             for item in data:
-                codes.extend(self.extract_property_codes(item))
+                codes.update(self.extract_property_codes(item))
 
         return codes


### PR DESCRIPTION
This pull request includes changes to the `extract_property_codes` method in the `bam_masterdata/checker/masterdata_validator.py` file to improve the handling of property codes. The most important change is the switch from using `extend` to `update` for updating the `codes` set, ensuring that duplicate codes are not added.

Improvements to property code extraction:

* [`bam_masterdata/checker/masterdata_validator.py`](diffhunk://#diff-cc0fbe4655ebe6bb48697ab4c4c45e6e077fa3f11f5f1c1b94c8a955486edc68L571-R575): Changed `codes.extend(self.extract_property_codes(value))` to `codes.update(self.extract_property_codes(value))` to prevent duplicates when adding property codes from nested structures.
* [`bam_masterdata/checker/masterdata_validator.py`](diffhunk://#diff-cc0fbe4655ebe6bb48697ab4c4c45e6e077fa3f11f5f1c1b94c8a955486edc68L571-R575): Changed `codes.extend(self.extract_property_codes(item))` to `codes.update(self.extract_property_codes(item))` to ensure unique property codes are maintained when iterating over lists.