### PR TITLE
Add raise error in checker CLI if validation fails

### DIFF
--- a/bam_masterdata/checker/checker.py
+++ b/bam_masterdata/checker/checker.py
@@ -74,7 +74,7 @@ class MasterdataChecker:
 
         # Load the validation rules
         if (
-            mode in ["self", "incoming", "validate", "all"]
+            mode in ["self", "incoming", "validate", "all", "individual"]
             and self.validation_rules == {}
         ):
             self.validation_rules = load_validation_rules(self.logger)

--- a/bam_masterdata/cli/cli.py
+++ b/bam_masterdata/cli/cli.py
@@ -410,7 +410,6 @@ def checker(file_path, mode, datamodel_path):
                 click.echo(
                     f"There are problems in the current model for entity {entity} that need to be solved"
                 )
-                click.echo(f"Errors: {errors}")
 
     # Check if there are problems with the incoming model
     if mode in ["incoming", "all", "validate"] and validation_results.get(
@@ -421,7 +420,6 @@ def checker(file_path, mode, datamodel_path):
                 click.echo(
                     f"There are problems in the incoming model in {file_path} for entity {entity} that need to be solved"
                 )
-                click.echo(f"Errors: {errors}")
 
     # Check if there are comparison problems
     if mode in ["compare", "all"] and validation_results.get("comparisons", {}):
@@ -430,7 +428,6 @@ def checker(file_path, mode, datamodel_path):
                 click.echo(
                     f"There are problems when checking the incoming model in {file_path} against the current model {datamodel_path} for entity {entity} that need to be solved"
                 )
-                click.echo(f"Errors: {errors}")
 
     # Check if there are individual repository problems
     if (
@@ -443,17 +440,19 @@ def checker(file_path, mode, datamodel_path):
                 click.echo(
                     f"There are problems in the individual repositories when validating them for entity {entity} that need to be solved"
                 )
-                click.echo(f"Errors: {errors}")
         for entity, errors in validation_results.get("comparisons", {}).items():
             if errors:
                 click.echo(
                     f"There are problems in the individual repositories when comparing them with respect to bam-masterdata for entity {entity} that need to be solved"
                 )
-                click.echo(f"Errors: {errors}")
 
     # Check if no problems were found
     if no_validation_errors(validation_results):
         click.echo("No problems found in the datamodel and incoming model.")
+    else:
+        raise click.ClickException(
+            "Problems found in the datamodel. Please, check the logs."
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request includes changes to the `bam_masterdata` package to add a new validation mode and improve error handling in the CLI. The most important changes include adding the "individual" mode to the validation rules and modifying the CLI to raise exceptions when validation errors are found.

### New validation mode:
* [`bam_masterdata/checker/checker.py`](diffhunk://#diff-a0701b8dd78689290bfd9c5740c542c2104e428f21a78e857d180ecd7b17b1acL77-R77): Added "individual" mode to the list of validation modes in the `check` method.

### Improved error handling in CLI:
* [`bam_masterdata/cli/cli.py`](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L413): Removed redundant error messages for various validation checks and added a new `click.ClickException` to be raised when validation errors are found. [[1]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L413) [[2]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L424) [[3]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L433) [[4]](diffhunk://#diff-8ffbbe9deaa2cc8b82ab93486458d62df589664aa13d06e6d47f588707b25841L446-R455)Delete click error printing

Add individual for loading validation rules