### PR TITLE
Remove validation for row_location

### DIFF
--- a/bam_masterdata/validation_rules/all_validation_rules.json
+++ b/bam_masterdata/validation_rules/all_validation_rules.json
@@ -1,0 +1,76 @@
+{
+  "code": {
+    "pattern": "^\\$?[A-Za-z0-9_.]+$"
+  },
+  "description": {
+    "pattern": ".*",
+    "is_description": true
+  },
+  "validation_script": {
+    "pattern": "^[A-Za-z0-9_\\.]+$",
+    "allow_empty": true
+  },
+  "auto_generated_codes": {
+    "is_bool": true
+  },
+  "main_dataset_pattern": {
+    "pattern": ".*",
+    "allow_empty": true
+  },
+  "main_dataset_path": {
+    "pattern": ".*",
+    "allow_empty": true
+  },
+  "property_label": {
+    "pattern": ".*"
+  },
+  "data_type": {
+    "is_data": true
+  },
+  "vocabulary_code": {
+    "pattern": "^\\$?[A-Za-z0-9_.]+$",
+    "allow_empty": true
+  },
+  "object_code": {
+    "pattern": "^\\$?[A-Za-z0-9_.]+$",
+    "allow_empty": true
+  },
+  "metadata": {
+    "pattern": ".*",
+    "allow_empty": true
+  },
+  "url_template": {
+    "pattern": "https?://(?:www\\.)?[a-zA-Z0-9-._~:/?#@!$&'()*+,;=%]+",
+    "is_url": true,
+    "allow_empty": true
+  },
+  "dynamic_script": {
+    "pattern": "^[A-Za-z0-9_\\.]+$",
+    "allow_empty": true
+  },
+  "mandatory": {
+    "is_bool": true
+  },
+  "show_in_edit_views": {
+    "is_bool": true
+  },
+  "section": {
+    "pattern": ".*"
+  },
+  "unique": {
+    "is_bool": true,
+    "allow_empty": true
+  },
+  "internal_assignment": {
+    "pattern": ".*",
+    "allow_empty": true
+  },
+  "generated_code_prefix": {
+    "pattern": ".*",
+    "extra_validation": "is_reduced_version"
+  },
+  "official": {
+    "is_bool": true,
+    "allow_empty": true
+  }
+}

--- a/bam_masterdata/validation_rules/validation_rules.json
+++ b/bam_masterdata/validation_rules/validation_rules.json
@@ -1,0 +1,109 @@
+{
+  "defs_validation": {
+    "code": {
+      "pattern": "^\\$?[A-Za-z0-9_.-]+$"
+    },
+    "description": {
+      "pattern": ".*",
+      "allow_empty": true,
+      "is_description": true
+    },
+    "validation_script": {
+      "pattern": "^[A-Za-z0-9_\\.]+$",
+      "allow_empty": true
+    },
+    "generated_code_prefix": {
+      "pattern": ".*",
+      "extra_validation": "is_reduced_version"
+    },
+    "main_dataset_pattern": {
+      "pattern": ".*",
+      "allow_empty": true
+    },
+    "main_dataset_path": {
+      "pattern": ".*",
+      "allow_empty": true
+    },
+      "auto_generated_codes": {
+      "is_bool": true
+    },
+    "url_template": {
+      "pattern": "https?://(?:www\\.)?[a-zA-Z0-9-._~:/?#@!$&'()*+,;=%]+",
+      "is_url": true,
+      "allow_empty": true
+    }
+  },
+  "properties_validation": {
+    "code": {
+      "pattern": "^\\$?[A-Za-z0-9_.-]+$"
+    },
+    "description": {
+      "pattern": ".*",
+      "allow_empty": true,
+      "is_description": true
+    },
+    "property_label": {
+      "pattern": ".*"
+    },
+    "data_type": {
+      "is_data": true
+    },
+    "vocabulary_code": {
+      "pattern": "^\\$?[A-Za-z0-9_.]+$",
+      "allow_empty": true
+    },
+    "object_code": {
+      "pattern": "^\\$?[A-Za-z0-9_.]+$",
+      "allow_empty": true
+    },
+    "metadata": {
+      "pattern": ".*",
+      "allow_empty": true
+    },
+    "dynamic_script": {
+      "pattern": "^[A-Za-z0-9_\\.]+$",
+      "allow_empty": true
+    },
+    "mandatory": {
+      "is_bool": true
+    },
+    "show_in_edit_views": {
+      "is_bool": true
+    },
+    "section": {
+      "pattern": "^([A-Z][a-z]*|[A-Z]+)( ([A-Z][a-z]*|[A-Z]+))*$",
+      "is_section": true,
+      "allow_empty": true
+    },
+    "unique": {
+      "is_bool": true,
+      "allow_empty": true
+    },
+    "internal_assignment": {
+      "pattern": ".*",
+      "allow_empty": true
+    }
+  },
+  "terms_validation": {
+    "code": {
+      "pattern": "^\\$?[A-Za-z0-9_.-]+$"
+    },
+    "description": {
+      "pattern": ".*",
+      "is_description": true,
+      "allow_empty": true
+    },
+    "url_template": {
+      "pattern": "https?://(?:www\\.)?[a-zA-Z0-9-._~:/?#@!$&'()*+,;=%]+",
+      "is_url": true,
+      "allow_empty": true
+    },
+    "label": {
+      "pattern": ".*"
+    },
+    "official": {
+      "is_bool": true,
+      "allow_empty": true
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces new validation rules for master data by adding two JSON files: `all_validation_rules.json` and `validation_rules.json`. These files define patterns, constraints, and metadata for validating various fields, ensuring consistent and robust data handling.

### Addition of validation rules:

* [`bam_masterdata/validation_rules/all_validation_rules.json`](diffhunk://#diff-1ee87f9dc9c76173e5578476acbd568b9879f3fbcb1d8123bfd5deaf5729346cR1-R76): Introduced a comprehensive set of validation rules for fields such as `code`, `description`, `validation_script`, `url_template`, and more. These rules include patterns, boolean constraints, and additional metadata validations.

* [`bam_masterdata/validation_rules/validation_rules.json`](diffhunk://#diff-0e4437e48baf4703944c690faa69209a426b1a3e127f94bb183b325e1cd3acc8R1-R109): Added categorized validation rules for `defs_validation`, `properties_validation`, and `terms_validation`. Each category specifies field-specific constraints, including patterns, boolean checks, and specialized validations like `is_section` or `is_description`.