### PR TITLE
Add structlog as runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ If you want to install it, do:
 pip install bam-masterdata
 ```
 
-In order to include the CLI functionalities, you have to add the optional `[dev]` dependencies when pip installing the package:
-```sh
-pip install bam-masterdata[dev]
-```
-
 ## Development
 
 If you want to develop locally this package, clone the project and enter in the workspace folder:

--- a/bam_masterdata/metadata/definitions.py
+++ b/bam_masterdata/metadata/definitions.py
@@ -1,15 +1,10 @@
 import datetime
 import re
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional
-
-if TYPE_CHECKING:
-    from pybis import Openbis
-    from structlog._config import BoundLoggerLazyProxy
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from bam_masterdata.openbis import OpenbisEntities
 from bam_masterdata.utils import code_to_class_name
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ dependencies = [
   "click",
   "pydantic~=2.10.5",
   "rdflib",
-  "h5py~=3.12.1"
+  "h5py~=3.12.1",
+  "python-decouple",
+  "structlog==24.4.0",
 ]
 
 [project.urls]
@@ -45,8 +47,6 @@ dev = [
   "pytest",
   "pytest-timeout",
   "pytest-cov",
-  "python-decouple",
-  "structlog==24.4.0",
 ]
 docu = [
   "mkdocs-material",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
I also handled a couple of minor fixes.

---

This pull request includes several changes to streamline the codebase, update dependencies, and adjust documentation. The most important changes include removing unused imports, modifying dependencies in `pyproject.toml`, and removing the `setup.py` file.

### Codebase cleanup:
* Removed unused imports from `bam_masterdata/metadata/definitions.py`, including `TYPE_CHECKING`, `Openbis`, `BoundLoggerLazyProxy`, and `OpenbisEntities`. This simplifies the file and removes unnecessary dependencies.

### Dependency updates:
* Added `python-decouple` and `structlog==24.4.0` to the main dependencies in `pyproject.toml` and removed them from the `dev` dependencies. This ensures these packages are available in production environments. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L34-R36) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L48-L49)

### Documentation adjustments:
* Removed the section in `README.md` about installing optional `[dev]` dependencies for CLI functionalities, as it is no longer relevant.

### Build system updates:
* Removed the `setup.py` file, as it is no longer needed with the use of `pyproject.toml` for build configuration.