### PR TITLE
Add mandatory check when setattr in objects

### DIFF
--- a/bam_masterdata/cli/entities_to_excel.py
+++ b/bam_masterdata/cli/entities_to_excel.py
@@ -52,7 +52,7 @@ def entities_to_excel(
         worksheet.append(header_values)
 
         # Properties assignment for ObjectType, DatasetType, and CollectionType
-        if obj_instance.cls_name in ["ObjectType", "DatasetType", "CollectionType"]:
+        if obj_instance.base_name in ["ObjectType", "DatasetType", "CollectionType"]:
             if not obj_instance.properties:
                 continue
             worksheet.append(
@@ -68,7 +68,7 @@ def entities_to_excel(
                     row.append(val)
                 worksheet.append(row)
         # Terms assignment for VocabularyType
-        elif obj_instance.cls_name == "VocabularyType":
+        elif obj_instance.base_name == "VocabularyType":
             if not obj_instance.terms:
                 continue
             worksheet.append(list(obj_instance.terms[0].excel_headers_map.values()))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,8 +144,12 @@ def generate_base_entity():
     return MockedEntity()
 
 
-def generate_object_type():
+def generate_object_type_miss_mandatory():
     return MockedObjectType()
+
+
+def generate_object_type():
+    return MockedObjectType(name="Mandatory name")
 
 
 def generate_object_type_longer():

--- a/tests/metadata/test_entities.py
+++ b/tests/metadata/test_entities.py
@@ -13,6 +13,7 @@ from tests.conftest import (
     generate_base_entity,
     generate_object_type,
     generate_object_type_longer,
+    generate_object_type_miss_mandatory,
     generate_vocabulary_type,
 )
 
@@ -131,7 +132,7 @@ class TestObjectType:
         assert isinstance(
             object_type._property_metadata["name"], PropertyTypeAssignment
         )
-        assert isinstance(object_type.name, PropertyTypeAssignment)
+        assert object_type.name == "Mandatory name"
 
         # Valid type
         object_type.name = "Test Object"
@@ -214,11 +215,18 @@ class TestCollectionType:
     def test_add(self):
         """Test the method `add` from the class `CollectionType`."""
         collection = CollectionType()
+
         with pytest.raises(
             TypeError,
             match="Expected an ObjectType instance, got `MockedVocabularyType`",
         ):
             entity_id = collection.add(generate_vocabulary_type())
+
+        with pytest.raises(
+            ValueError,
+            match="The following mandatory fields are missing for ObjectType 'MockedObjectType': name",
+        ):
+            entity_id = collection.add(generate_object_type_miss_mandatory())
 
         entity_id = collection.add(generate_object_type())
         assert entity_id.startswith("MOCKOBJTYPE")


### PR DESCRIPTION
This pull request refactors entity class naming conventions and introduces stricter validation for mandatory properties when adding objects to collections. The most significant changes include renaming the `cls_name` property to `base_name` across entity classes, updating related usages, and enforcing mandatory property checks in the `CollectionType.add` method. Corresponding tests have been updated to reflect these changes and verify correct behavior.

**Refactoring of entity class naming:**

* Renamed the property `cls_name` to `base_name` in all entity classes (`BaseEntity`, `VocabularyType`, `CollectionType`, `DatasetType`) and updated all usages to reference `base_name` instead of `cls_name`. [[1]](diffhunk://#diff-e8d59d232a103d745395193665c31c153d84d50db8e0ec82737b01e7dcbda865L596-R596) [[2]](diffhunk://#diff-e8d59d232a103d745395193665c31c153d84d50db8e0ec82737b01e7dcbda865L710-R710) [[3]](diffhunk://#diff-e8d59d232a103d745395193665c31c153d84d50db8e0ec82737b01e7dcbda865L792-R792) [[4]](diffhunk://#diff-e8d59d232a103d745395193665c31c153d84d50db8e0ec82737b01e7dcbda865L915-R928) [[5]](diffhunk://#diff-57510029e91d2bb847ef7bbe78767d5b4616182ad3d6ea58909d4e5c5a7072d0L55-R55) [[6]](diffhunk://#diff-57510029e91d2bb847ef7bbe78767d5b4616182ad3d6ea58909d4e5c5a7072d0L71-R71)

**Validation of mandatory properties:**

* Enhanced the `CollectionType.add` method to check for missing mandatory properties in `ObjectType` instances. If any mandatory fields are missing, a `ValueError` is raised listing the missing fields.

**Test updates and improvements:**

* Added new test fixtures in `tests/conftest.py` to generate object types with and without mandatory properties, enabling more thorough testing of the new validation logic.
* Updated `test_setattr` in `tests/metadata/test_entities.py` to verify that the `name` property is correctly assigned and no longer an instance of `PropertyTypeAssignment`.
* Extended tests for `CollectionType.add` to assert that a `ValueError` is raised when mandatory fields are missing, and verified correct behavior when all mandatory fields are present.

**Minor code improvements:**

* Simplified property assignment logic in the `model_validator_after_init` method by removing the unused `attr_name` variable.