### PR TITLE
182 validation of datetime in masterdata and pybis

### DIFF
--- a/bam_masterdata/metadata/entities.py
+++ b/bam_masterdata/metadata/entities.py
@@ -546,6 +546,13 @@ class ObjectType(BaseEntity):
                     expected_type = meta[key].data_type.pytype
                     if expected_type is datetime.datetime and isinstance(value, str):
                         # Try validate datetime from string
+                        if isinstance(value, datetime.datetime):
+                            try:
+                                value = value.strftime("%Y-%m-%d %H:%M:%S")
+                            except ValueError:
+                                raise ValueError(
+                                    f"Invalid datetime format for '{key}': Expected ISO format string, got '{value}'"
+                                )
                         try:
                             datetime.datetime.fromisoformat(value)
                             expected_type = str

--- a/bam_masterdata/metadata/entities.py
+++ b/bam_masterdata/metadata/entities.py
@@ -1,3 +1,4 @@
+import datetime
 import inspect
 import json
 from collections.abc import Callable
@@ -543,6 +544,15 @@ class ObjectType(BaseEntity):
                 if key in meta:
                     # Typcheck
                     expected_type = meta[key].data_type.pytype
+                    if expected_type is datetime.datetime and isinstance(value, str):
+                        # Try validate datetime from string
+                        try:
+                            datetime.datetime.fromisoformat(value)
+                            expected_type = str
+                        except ValueError:
+                            raise ValueError(
+                                f"Invalid datetime format for '{key}': Expected ISO format string, got '{value}'"
+                            )
                     if expected_type and not isinstance(value, expected_type):
                         raise TypeError(
                             f"Invalid type for '{key}': Expected {expected_type.__name__}, got {type(value).__name__}"


### PR DESCRIPTION
changed logic behind the _setattr_ function for object_types to validate datetime as strings for imports using pyBis