### PR TITLE
Fix printing of classes

### DIFF
--- a/bam_masterdata/metadata/entities.py
+++ b/bam_masterdata/metadata/entities.py
@@ -70,17 +70,25 @@ class BaseEntity(BaseModel):
 
     def __repr__(self):
         # Filter for attributes that are `PropertyTypeAssignment` and set to a finite value
+        class_prop_name = None
         fields = []
         for key, metadata in self._property_metadata.items():
             if isinstance(metadata, PropertyTypeAssignment):
                 value = getattr(self, key, None)
                 # Only include set attributes
                 if value is not None and not isinstance(value, PropertyTypeAssignment):
+                    if key == "name":
+                        class_prop_name = value
                     fields.append(f"{key}={repr(value)}")
 
         # Format the output
-        class_name = self.__class__.__name__
+        class_name = self.cls_name
+        if class_prop_name:  # adding `name` if available
+            class_name = f"{class_prop_name}:{class_name}"
         return f"{class_name}({', '.join(fields)})"
+
+    # Overwritting the __str__ method to use the same representation as __repr__
+    __str__ = __repr__
 
     @property
     def cls_name(self) -> str:

--- a/bam_masterdata/metadata/entities.py
+++ b/bam_masterdata/metadata/entities.py
@@ -87,7 +87,7 @@ class BaseEntity(BaseModel):
             class_name = f"{class_prop_name}:{class_name}"
         return f"{class_name}({', '.join(fields)})"
 
-    # Overwritting the __str__ method to use the same representation as __repr__
+    # Overwriting the __str__ method to use the same representation as __repr__
     __str__ = __repr__
 
     @property

--- a/tests/metadata/test_entities.py
+++ b/tests/metadata/test_entities.py
@@ -45,7 +45,7 @@ class TestBaseEntity:
         entity = generate_base_entity()
         assert repr(entity) == "MockedEntity()"
         entity.name = "Test"
-        assert repr(entity) == "MockedEntity(name='Test')"
+        assert repr(entity) == "Test:MockedEntity(name='Test')"
 
     def test_to_json(self):
         """Test the method `to_json` from the class `BaseEntity`."""
@@ -222,15 +222,15 @@ class TestCollectionType:
         obj_id = collection.add(generate_object_type())
         assert (
             repr(collection)
-            == f"CollectionType(attached_objects={{'{obj_id}': MockedObjectType(name='Mandatory name')}}, relationships={{}})"
+            == f"CollectionType(attached_objects={{'{obj_id}': Mandatory name:MockedObjectType(name='Mandatory name')}}, relationships={{}})"
         )
 
         obj_id_2 = collection.add(generate_object_type())
         relation_id = collection.add_relationship(obj_id, obj_id_2)
         assert (
             repr(collection)
-            == f"CollectionType(attached_objects={{'{obj_id}': MockedObjectType(name='Mandatory name'), "
-            f"'{obj_id_2}': MockedObjectType(name='Mandatory name')}}, relationships={{'{relation_id}': ('{obj_id}', '{obj_id_2}')}})"
+            == f"CollectionType(attached_objects={{'{obj_id}': Mandatory name:MockedObjectType(name='Mandatory name'), "
+            f"'{obj_id_2}': Mandatory name:MockedObjectType(name='Mandatory name')}}, relationships={{'{relation_id}': ('{obj_id}', '{obj_id_2}')}})"
         )
 
     def test_add(self):


### PR DESCRIPTION
This pull request introduces improvements to the string representation of entity objects in `bam_masterdata/metadata/entities.py`, making their output more informative and consistent. The main change is to include the value of the `name` property (if present) in the class name portion of the representation, and to ensure that both `__repr__` and `__str__` use the same format.

Enhancements to entity string representation:

* Updated the `__repr__` method to prepend the value of the `name` property to the class name in the output, improving clarity when inspecting objects.
* Overwrote the `__str__` method to use the same output as `__repr__`, ensuring consistency in string representations.