### PR TITLE
allow Openbis session in ologin

### DIFF
--- a/bam_masterdata/openbis/login.py
+++ b/bam_masterdata/openbis/login.py
@@ -3,16 +3,23 @@ from pybis import Openbis
 
 
 # Connect to openBIS
-def ologin(url: str = "") -> Openbis:
+def ologin(url: str | Openbis = "") -> Openbis:
     """
     Connect to openBIS using the credentials stored in the environment variables.
 
+    If an existing Openbis session is provided, the session is returned.
+
     Args:
-        url (str): The URL of the openBIS instance. Defaults to the value of the `OPENBIS_URL` environment variable.
+        url (str, Openbis): The URL of the openBIS instance. Defaults to the value of the `OPENBIS_URL` environment variable.
+        An existing Openbis session can be provided.
 
     Returns:
         Openbis: Openbis object for the specific openBIS instance defined in `URL`.
     """
-    o = Openbis(url)
-    o.login(environ("OPENBIS_USERNAME"), environ("OPENBIS_PASSWORD"), save_token=True)
+    if not isinstance(url, Openbis):
+        o = Openbis(url)
+
+    if not o.is_session_activ():
+        o.login(environ("OPENBIS_USERNAME"), environ("OPENBIS_PASSWORD"), save_token=True)
+
     return o


### PR DESCRIPTION
Currently, the library uses the `ologin` function open Openbis sessions in various places. `ologin` is dependent on a specific environmental variables.

To allow more flexible use of the library, this small patch enables the user to pass through existing Openbis sessions that might have been opened in a different context.