### PR TITLE
Hotfix missing code in run_parser

### DIFF
--- a/bam_masterdata/cli/run_parser.py
+++ b/bam_masterdata/cli/run_parser.py
@@ -198,6 +198,7 @@ def run_parser(
                 if not collection_name:
                     object_openbis = openbis.new_object(
                         type=object_instance.defs.code,
+                        code=object_instance.code,
                         space=space,
                         project=project,
                         props=obj_props,
@@ -205,6 +206,7 @@ def run_parser(
                 else:
                     object_openbis = openbis.new_object(
                         type=object_instance.defs.code,
+                        code=object_instance.code,
                         space=space,
                         project=project,
                         collection=collection_openbis,


### PR DESCRIPTION
This pull request makes a small update to the object creation logic in `bam_masterdata/cli/run_parser.py`. The change ensures that the `code` attribute from `object_instance` is explicitly set when creating new OpenBIS objects.