### PR TITLE
add *None* to SampleHolderMaterial vocabulary

### DIFF
--- a/bam_masterdata/datamodel/vocabulary_types.py
+++ b/bam_masterdata/datamodel/vocabulary_types.py
@@ -79418,6 +79418,12 @@ class SampleHolderMaterial(VocabularyType):
         description="""Scotch Magic Tape//Scotch Magic Tape""",
     )
 
+    sam_hol_mat_none = VocabularyTerm(
+        code="SAM_HOL_MAT_NONE",
+        label="None",
+        description="""None//Keins""",
+    )
+
 
 class ShortRngOrd(VocabularyType):
     defs = VocabularyTypeDef(


### PR DESCRIPTION
I need to extend the controlledvocabulary for the SampleHolderMaterial, especially sample holders with do not have additional material contributing to the measurement (in the beam).