### PR TITLE
add MouseMeasurement type for integrating MOUSE instrument metadata

### DIFF
--- a/bam_masterdata/datamodel/object_types.py
+++ b/bam_masterdata/datamodel/object_types.py
@@ -12698,7 +12698,7 @@ class Crystal(MatSimStructure):
 #   EXPERIMENTAL_GOALS, SPREADSHEET, REFERENCE, PUBLICATION, COMMENTS
 class MouseMeasurement(SaxsMeasurement):
     defs = ObjectTypeDef(
-        code="EXPERIMENTAL_STEP.MOUSE_MEASUREMENT",
+        code="EXPERIMENTAL_STEP.SAXS_MEASUREMENT.MOUSE_MEASUREMENT",
         description="""Metadata of SAXS measurements of sample at MOUSE // Metadaten der SAXS-Messungen einer Probe mit MOUSE""",
         generated_code_prefix="EXP.MOME_",
     )


### PR DESCRIPTION
Proposing a specialisation of EXPERIMENTAL_STEP to store basic metadata for a set of measurement on each sample with our MOUSE instrument (fyi: https://lookingatnothing.com/index.php/archives/4053 and here https://lookingatnothing.com/index.php/archives/4353)
Tested and scripts ready for upload ;)