### PR TITLE
287 include parent child relationships from objects already in the inventory

### DIFF
--- a/bam_masterdata/cli/run_parser.py
+++ b/bam_masterdata/cli/run_parser.py
@@ -531,6 +531,7 @@ def run_parser_with_transactions(
                     logger.warning(f"Error occurred while fetching parent object: {e}")
             else:
                 parent_identifier = openbis_id_map[parent_id]
+                parent = openbis.get_object(parent_identifier)
             if isinstance(child_id, dict):
                 try:
                     child = openbis.get_object(**child_id)

--- a/bam_masterdata/cli/run_parser.py
+++ b/bam_masterdata/cli/run_parser.py
@@ -462,11 +462,11 @@ def run_parser_with_transactions(
     # TODO (May 2026) if later transactions support datasets change it to transaction.
     for object_instance in collection.attached_objects.values():
         try:
-            if object_instance.dataset != []:
+            if object_instance.datasets != []:
                 attached_datasets = openbis.new_dataset(
                     type="RAW_DATA",
                     sample=identifier,
-                    files=object_instance.dataset,
+                    files=object_instance.datasets,
                 )
 
                 attached_datasets.save()
@@ -504,23 +504,47 @@ def run_parser_with_transactions(
 
     # ---- RELATIONSHIPS IN TRANSACTION ----
     for parent_id, child_id in collection.relationships.values():
-        if parent_id not in openbis_id_map or child_id not in openbis_id_map:
-            continue
+        if not isinstance(parent_id, dict) and not isinstance(child_id, dict):
+            if parent_id not in openbis_id_map or child_id not in openbis_id_map:
+                logger.warning(
+                    f"Skipping relationship with parent_id {parent_id} and child_id {child_id} because one of them is not found attached or in OpenBIS."
+                )
+                continue
+        if not isinstance(parent_id, dict) and not isinstance(child_id, dict):
+            parent_identifier = openbis_id_map[parent_id]
+            child_identifier = openbis_id_map[child_id]
 
-        parent_identifier = openbis_id_map[parent_id]
-        child_identifier = openbis_id_map[child_id]
+            parent = openbis.get_object(parent_identifier)
+            child = openbis.get_object(child_identifier)
 
-        parent_identifier
-        child_identifier
-        parent = openbis.get_object(parent_identifier)
-        child = openbis.get_object(child_identifier)
+            child.add_parents(parent)
+            rel_transaction.add(child)
 
-        child.add_parents(parent)
-        rel_transaction.add(child)
+            logger.info(
+                f"Prepared relationship: {child_identifier} -> parent {parent_identifier}"
+            )
+        else:
+            if isinstance(parent_id, dict):
+                try:
+                    parent = openbis.get_object(**parent_id)
+                except Exception as e:
+                    logger.warning(f"Error occurred while fetching parent object: {e}")
+            else:
+                parent_identifier = openbis_id_map[parent_id]
+            if isinstance(child_id, dict):
+                try:
+                    child = openbis.get_object(**child_id)
+                except Exception as e:
+                    logger.warning(f"Error occurred while fetching child object: {e}")
+            else:
+                child_identifier = openbis_id_map[child_id]
+                child = openbis.get_object(child_identifier)
+            child.add_parents(parent)
+            rel_transaction.add(child)
 
-        logger.info(
-            f"Prepared relationship: {child_identifier} -> parent {parent_identifier}"
-        )
+            logger.info(
+                f"Prepared relationship: {child.identifier} -> parent {parent.identifier}"
+            )
 
     try:
         rel_transaction.commit()

--- a/bam_masterdata/cli/run_parser.py
+++ b/bam_masterdata/cli/run_parser.py
@@ -219,6 +219,36 @@ def make_unique_code(code: str, seen_codes: dict) -> str:
     return f"{code}__dup{seen_codes[code]}"
 
 
+def _get_entity(
+    openbis,
+    openbis_id_map: dict[str, str],
+    obj: str | dict,
+    object_role: str,
+):
+    """
+    Resolve an object reference to an OpenBIS object.
+
+    Args:
+        openbis: OpenBIS connection instance.
+        openbis_id_map: Mapping from internal IDs to OpenBIS identifiers.
+        obj: Either an internal object ID or a dictionary that can be passed directly to `openbis.get_object`.
+        object_role: Used for logging (e.g. "parent" or "child").
+
+    Returns:
+        OpenBIS object instance.
+    """
+
+    if isinstance(obj, dict):
+        try:
+            return openbis.get_object(**obj)
+        except Exception as e:
+            logger.warning(f"Error occurred while fetching {object_role} object: {e}")
+            raise
+
+    identifier = openbis_id_map[obj]
+    return openbis.get_object(identifier)
+
+
 def run_parser(
     openbis: Openbis | None = None,
     space_name: str = "",
@@ -503,49 +533,40 @@ def run_parser_with_transactions(
             logger.warning(f"Error preparing dataset {files}: {e}")
 
     # ---- RELATIONSHIPS IN TRANSACTION ----
-    for parent_id, child_id in collection.relationships.values():
-        if not isinstance(parent_id, dict) and not isinstance(child_id, dict):
-            if parent_id not in openbis_id_map or child_id not in openbis_id_map:
-                logger.warning(
-                    f"Skipping relationship with parent_id {parent_id} and child_id {child_id} because one of them is not found attached or in OpenBIS."
-                )
-                continue
-        if not isinstance(parent_id, dict) and not isinstance(child_id, dict):
-            parent_identifier = openbis_id_map[parent_id]
-            child_identifier = openbis_id_map[child_id]
-
-            parent = openbis.get_object(parent_identifier)
-            child = openbis.get_object(child_identifier)
-
-            child.add_parents(parent)
-            rel_transaction.add(child)
-
-            logger.info(
-                f"Prepared relationship: {child_identifier} -> parent {parent_identifier}"
+    for parent, child in collection.relationships.values():
+        if (
+            not isinstance(parent, dict)
+            and not isinstance(child, dict)
+            and (parent not in openbis_id_map or child not in openbis_id_map)
+        ):
+            logger.warning(
+                f"Skipping relationship with parent {parent} and child {child} "
+                "because one of them is not found attached or in OpenBIS."
             )
-        else:
-            if isinstance(parent_id, dict):
-                try:
-                    parent = openbis.get_object(**parent_id)
-                except Exception as e:
-                    logger.warning(f"Error occurred while fetching parent object: {e}")
-            else:
-                parent_identifier = openbis_id_map[parent_id]
-                parent = openbis.get_object(parent_identifier)
-            if isinstance(child_id, dict):
-                try:
-                    child = openbis.get_object(**child_id)
-                except Exception as e:
-                    logger.warning(f"Error occurred while fetching child object: {e}")
-            else:
-                child_identifier = openbis_id_map[child_id]
-                child = openbis.get_object(child_identifier)
-            child.add_parents(parent)
-            rel_transaction.add(child)
+            continue
+        parent_obj = _get_entity(
+            openbis,
+            openbis_id_map,
+            parent,
+            "parent",
+        )
+        child_obj = _get_entity(
+            openbis,
+            openbis_id_map,
+            child,
+            "child",
+        )
 
-            logger.info(
-                f"Prepared relationship: {child.identifier} -> parent {parent.identifier}"
-            )
+        if parent_obj is None or child_obj is None:
+            continue
+
+        child_obj.add_parents(parent_obj)
+        rel_transaction.add(child_obj)
+
+        logger.info(
+            f"Prepared relationship: "
+            f"{child_obj.identifier} -> parent {parent_obj.identifier}"
+        )
 
     try:
         rel_transaction.commit()

--- a/bam_masterdata/metadata/entities.py
+++ b/bam_masterdata/metadata/entities.py
@@ -1029,6 +1029,19 @@ def generate_object_relationship_id(parent_id: str, child_id: str) -> str:
     return f"{parent_id}>>{child_id}"
 
 
+def generate_dict_id(dict: dict) -> str:
+    """
+    Generate a unique identifier for a dictionary .
+
+    Args:
+        dict (dict): The dictionary for which to generate the identifier.
+
+    Returns:
+        str: A unique identifier string for the dictionary.
+    """
+    return f"{hash(frozenset(dict.items()))}"
+
+
 class CollectionType(ObjectType):
     model_config = ConfigDict(
         ignored_types=(
@@ -1155,13 +1168,13 @@ class CollectionType(ObjectType):
             )
         del self.attached_objects[object_id]
 
-    def add_relationship(self, parent_id: str, child_id: str) -> str:
+    def add_relationship(self, parent_id: str | dict, child_id: str | dict) -> str:
         """
         Add a relationship between two object types in the collection type.
 
         Args:
-            parent_id (str): The unique identifier of the parent object type.
-            child_id (str): The unique identifier of the child object type.
+            parent_id (str | dict): The unique identifier of the parent object type.
+            child_id (str | dict): The unique identifier of the child object type.
 
         Returns:
             str: The unique identifier of the relationship created, which is a concatenation of the parent
@@ -1171,15 +1184,27 @@ class CollectionType(ObjectType):
             raise ValueError(
                 "Both `parent_id` and `child_id` must be provided to add a relationship."
             )
-        if (
-            parent_id not in self.attached_objects.keys()
-            or child_id not in self.attached_objects.keys()
-        ):
-            raise ValueError(
-                "Both `parent_id` and `child_id` must be assigned to objects attached to the collection."
+        for obj_id in (parent_id, child_id):
+            if not isinstance(obj_id, dict) and obj_id not in self.attached_objects:
+                raise ValueError(
+                    "Both `parent_id` and `child_id` must be assigned to objects attached to the collection or existing in the system."
+                )
+        if not isinstance(parent_id, dict) and not isinstance(child_id, dict):
+            relationship_id = generate_object_relationship_id(parent_id, child_id)
+            self.relationships[relationship_id] = (parent_id, child_id)
+        else:
+            parent = (
+                generate_dict_id(parent_id)
+                if isinstance(parent_id, dict)
+                else parent_id
             )
-        relationship_id = generate_object_relationship_id(parent_id, child_id)
-        self.relationships[relationship_id] = (parent_id, child_id)
+
+            child = (
+                generate_dict_id(child_id) if isinstance(child_id, dict) else child_id
+            )
+
+            relationship_id = generate_object_relationship_id(parent, child)
+            self.relationships[relationship_id] = (parent_id, child_id)
         return relationship_id
 
     def remove_relationship(self, relationship_id: str) -> None:

--- a/bam_masterdata/metadata/entities.py
+++ b/bam_masterdata/metadata/entities.py
@@ -1168,43 +1168,51 @@ class CollectionType(ObjectType):
             )
         del self.attached_objects[object_id]
 
-    def add_relationship(self, parent_id: str | dict, child_id: str | dict) -> str:
+    def add_relationship(self, parent: str | dict, child: str | dict) -> str:
         """
         Add a relationship between two object types in the collection type.
 
         Args:
-            parent_id (str | dict): The unique identifier of the parent object type.
-            child_id (str | dict): The unique identifier of the child object type.
+            parent (str | dict):
+                Either the unique identifier of the parent object type or a
+                dictionary representation of the parent object type.
+            child (str | dict):
+                Either the unique identifier of the child object type or a
+                dictionary representation of the child object type.
 
         Returns:
-            str: The unique identifier of the relationship created, which is a concatenation of the parent
-            and child IDs.
+            str:
+                The unique identifier of the created relationship, generated
+                from the resolved parent and child identifiers.
         """
-        if not parent_id or not child_id:
+        if not parent or not child:
             raise ValueError(
-                "Both `parent_id` and `child_id` must be provided to add a relationship."
+                "Both `parent` and `child` must be provided to add a relationship."
             )
-        for obj_id in (parent_id, child_id):
-            if not isinstance(obj_id, dict) and obj_id not in self.attached_objects:
+
+        for obj in (parent, child):
+            if not isinstance(obj, dict) and obj not in self.attached_objects:
                 raise ValueError(
-                    "Both `parent_id` and `child_id` must be assigned to objects attached to the collection or existing in the system."
+                    "Both `parent` and `child` must be assigned to objects attached to the collection or being a dict readable by the system."
                 )
-        if not isinstance(parent_id, dict) and not isinstance(child_id, dict):
-            relationship_id = generate_object_relationship_id(parent_id, child_id)
-            self.relationships[relationship_id] = (parent_id, child_id)
-        else:
-            parent = (
-                generate_dict_id(parent_id)
-                if isinstance(parent_id, dict)
-                else parent_id
-            )
 
-            child = (
-                generate_dict_id(child_id) if isinstance(child_id, dict) else child_id
-            )
-
+        if not isinstance(parent, dict) and not isinstance(child, dict):
             relationship_id = generate_object_relationship_id(parent, child)
-            self.relationships[relationship_id] = (parent_id, child_id)
+            self.relationships[relationship_id] = (parent, child)
+        else:
+            resolved_parent = (
+                generate_dict_id(parent) if isinstance(parent, dict) else parent
+            )
+
+            resolved_child = (
+                generate_dict_id(child) if isinstance(child, dict) else child
+            )
+
+            relationship_id = generate_object_relationship_id(
+                resolved_parent, resolved_child
+            )
+            self.relationships[relationship_id] = (parent, child)
+
         return relationship_id
 
     def remove_relationship(self, relationship_id: str) -> None:

--- a/tests/metadata/test_entities.py
+++ b/tests/metadata/test_entities.py
@@ -490,7 +490,7 @@ class TestCollectionType:
 
         with pytest.raises(
             ValueError,
-            match="Both `parent_id` and `child_id` must be provided to add a relationship.",
+            match="Both `parent` and `child` must be provided to add a relationship.",
         ):
             collection.add_relationship("", "")
 
@@ -499,7 +499,7 @@ class TestCollectionType:
 
         with pytest.raises(
             ValueError,
-            match="Both `parent_id` and `child_id` must be assigned to objects attached to the collection.",
+            match="Both `parent` and `child` must be assigned to objects attached to the collection.",
         ):
             collection.add_relationship(parent_id, "NOT_A_CHILD_ID")
 


### PR DESCRIPTION
Entities:
- changed the add_relationship function to accept dictionarys
- added a function to get a unique code for a dictionary

Parser:
- added feature to create relationships with OpenBIS existing objects

Fixed:
- Last merge removed the @property from dataset attribute in object_type to decrease redundancy. This resulted in a small attribute change "dataset -> datasets"