### PR TITLE
rework run parser test cases to work with the new transaction logic

### DIFF
--- a/bam_masterdata/cli/run_parser.py
+++ b/bam_masterdata/cli/run_parser.py
@@ -31,27 +31,6 @@ def _parser_init(
     Returns:
         tuple: A tuple containing (collection, space, project, collection_openbis) if successful, None otherwise.
     """
-    # Ensure openbis is provided
-    if openbis is None:
-        logger.error("An instance of Openbis must be provided for the parser to run.")
-        return
-    # Ensure the space, project, and collection are set
-    if not project_name:
-        logger.error("The Project name must be specified for the parser to run.")
-        return
-    # Ensure the files_parser is not empty
-    if not files_parser:
-        logger.error(
-            "No files or parsers to parse. Please provide valid file paths or contact an Admin to add missing parser."
-        )
-        return
-    # Ensure collection_type is valid
-    if collection_type not in ["COLLECTION", "DEFAULT_EXPERIMENT"]:
-        logger.error(
-            f"Invalid collection_type '{collection_type}'. Must be either 'COLLECTION' or 'DEFAULT_EXPERIMENT'."
-        )
-        return
-
     # Specify the space
     try:
         space = openbis.get_space(space_name)
@@ -277,6 +256,26 @@ def run_parser(
         files_parser (dict): A dictionary where keys are parser instances and values are lists of file paths to be parsed. E.g., {MasterdataParserExample(): ["path/to/file.json", "path/to/another_file.json"]}
         collection_type (str): The type of collection to create in openBIS. Options are "COLLECTION" or "DEFAULT_EXPERIMENT". Defaults to "COLLECTION".
     """
+    if openbis is None:
+        logger.error("An instance of Openbis must be provided for the parser to run.")
+        return
+    # Ensure the space, project, and collection are set
+    if not project_name:
+        logger.error("The Project name must be specified for the parser to run.")
+        return
+    # Ensure the files_parser is not empty
+    if not files_parser:
+        logger.error(
+            "No files or parsers to parse. Please provide valid file paths or contact an Admin to add missing parser."
+        )
+        return
+    # Ensure collection_type is valid
+    if collection_type not in ["COLLECTION", "DEFAULT_EXPERIMENT"]:
+        logger.error(
+            f"Invalid collection_type '{collection_type}'. Must be either 'COLLECTION' or 'DEFAULT_EXPERIMENT'."
+        )
+        return
+
     collection, space, project, collection_openbis = _parser_init(
         openbis=openbis,
         space_name=space_name,
@@ -416,6 +415,26 @@ def run_parser_with_transactions(
         files_parser (dict): A dictionary where keys are parser instances and values are lists of file paths to be parsed. E.g., {MasterdataParserExample(): ["path/to/file.json", "path/to/another_file.json"]}
         collection_type (str): The type of collection to create in openBIS. Options are "COLLECTION" or "DEFAULT_EXPERIMENT". Defaults to "COLLECTION".
     """
+    if openbis is None:
+        logger.error("An instance of Openbis must be provided for the parser to run.")
+        return
+    # Ensure the space, project, and collection are set
+    if not project_name:
+        logger.error("The Project name must be specified for the parser to run.")
+        return
+    # Ensure the files_parser is not empty
+    if not files_parser:
+        logger.error(
+            "No files or parsers to parse. Please provide valid file paths or contact an Admin to add missing parser."
+        )
+        return
+    # Ensure collection_type is valid
+    if collection_type not in ["COLLECTION", "DEFAULT_EXPERIMENT"]:
+        logger.error(
+            f"Invalid collection_type '{collection_type}'. Must be either 'COLLECTION' or 'DEFAULT_EXPERIMENT'."
+        )
+        return
+
     collection, space, project, collection_openbis = _parser_init(
         openbis=openbis,
         space_name=space_name,

--- a/tests/cli/test_run_parser.py
+++ b/tests/cli/test_run_parser.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from bam_masterdata.cli.run_parser import run_parser
+from bam_masterdata.cli.run_parser import run_parser, run_parser_with_transactions
 from bam_masterdata.logger import log_storage
 from tests.conftest import (
     TestParser,
@@ -12,7 +12,7 @@ from tests.conftest import (
 
 def test_run_parser_missing_openbis(cleared_log_storage):
     """Test that `run_parser` returns early if openbis is None"""
-    run_parser(
+    run_parser_with_transactions(
         openbis=None,
         space_name="TEST_SPACE",
         project_name="TEST_PROJECT",
@@ -20,14 +20,14 @@ def test_run_parser_missing_openbis(cleared_log_storage):
         files_parser={},
     )
     assert any(
-        "instance of Openbis must be provided" in log["event"]
+        "An instance of Openbis must be provided for the parser to run." in log["event"]
         for log in cleared_log_storage
     )
 
 
 def test_run_parser_missing_project_name(cleared_log_storage, mock_openbis):
     """Test that `run_parser` returns early if project_name is empty"""
-    run_parser(
+    run_parser_with_transactions(
         openbis=mock_openbis,
         space_name="TEST_SPACE",
         project_name="",
@@ -43,7 +43,7 @@ def test_run_parser_empty_files_parser(cleared_log_storage, mock_openbis):
     """Test that run_parser returns early if files_parser is empty"""
     log_storage.clear()
 
-    run_parser(
+    run_parser_with_transactions(
         openbis=mock_openbis,
         space_name="TEST_SPACE",
         project_name="TEST_PROJECT",
@@ -61,7 +61,7 @@ def test_run_parser_with_test_parser(cleared_log_storage, mock_openbis):
     """Test run_parser with `TestParser`."""
     file = "./tests/data/cli/test_parser.txt"
     files_parser = {TestParser(): [file]}
-    run_parser(
+    run_parser_with_transactions(
         openbis=mock_openbis,
         space_name="USERNAME_SPACE",
         project_name="TEST_PROJECT",
@@ -100,7 +100,7 @@ def test_run_parser_with_object_reference(cleared_log_storage, mock_openbis):
 
     file = "./tests/data/cli/test_parser.txt"
     files_parser = {TestParserWithObjectReference(): [file]}
-    run_parser(
+    run_parser_with_transactions(
         openbis=mock_openbis,
         space_name="TEST_SPACE",
         project_name="TEST_PROJECT",
@@ -128,7 +128,7 @@ def test_run_parser_with_default_experiment_type(cleared_log_storage, mock_openb
     """Test run_parser with DEFAULT_EXPERIMENT collection type."""
     file = "./tests/data/cli/test_parser.txt"
     files_parser = {TestParser(): [file]}
-    run_parser(
+    run_parser_with_transactions(
         openbis=mock_openbis,
         space_name="USERNAME_SPACE",
         project_name="TEST_PROJECT",
@@ -149,7 +149,7 @@ def test_run_parser_defaults_to_collection_type(cleared_log_storage, mock_openbi
     file = "./tests/data/cli/test_parser.txt"
     files_parser = {TestParser(): [file]}
     # Call without specifying collection_type - should default to "COLLECTION"
-    run_parser(
+    run_parser_with_transactions(
         openbis=mock_openbis,
         space_name="USERNAME_SPACE",
         project_name="TEST_PROJECT",

--- a/tests/cli/test_run_parser.py
+++ b/tests/cli/test_run_parser.py
@@ -70,8 +70,15 @@ def test_run_parser_with_test_parser(cleared_log_storage, mock_openbis):
         collection_type="COLLECTION",
     )
 
+    assert mock_openbis.obj_transaction.commit.called
+    assert mock_openbis.rel_transaction.commit.called
+
+    assert mock_openbis.obj_transaction.add.call_count == 1
+
+    mock_openbis.obj_transaction.commit.assert_called_once()
+
     # Check that objects were created in openbis
-    assert len(mock_openbis._objects) == 1
+    assert len(mock_openbis.obj_transaction.objects) == 1
 
     # Check logs for success messages
     # logs = log_storage  # log_storage is already a list
@@ -110,7 +117,7 @@ def test_run_parser_with_object_reference(cleared_log_storage, mock_openbis):
     )
 
     # Only 2 instruments are created (the person is referenced but not persisted)
-    assert len(mock_openbis._objects) == 2
+    assert len(mock_openbis.obj_transaction.objects) == 3
 
     # Check logs for success messages
     assert any("Added person object" in log["event"] for log in cleared_log_storage)
@@ -164,4 +171,4 @@ def test_run_parser_defaults_to_collection_type(cleared_log_storage, mock_openbi
     assert any("Added test object" in log["event"] for log in cleared_log_storage)
 
 
-# TODO add other tests for the different situations in `run_parser()` and parsers from `conftest.py`
+# TODO add other tests for the different situations in `run_parser_with_transactions()` and parsers from `conftest.py`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,6 +194,33 @@ def mock_openbis():
     mock_openbis._objects = []
     mock_openbis.new_object.side_effect = new_object
 
+    # Mock transaction for adding objects
+    obj_transaction = MagicMock()
+    rel_transaction = MagicMock()
+
+    mock_openbis.new_transaction.side_effect = [
+        obj_transaction,
+        rel_transaction,
+    ]
+
+    obj_transaction.objects = []
+    rel_transaction.relationships = []
+
+    def add_obj(obj):
+        obj_transaction.objects.append(obj)
+
+    def add_rel(rel):
+        rel_transaction.relationships.append(rel)
+
+    obj_transaction.add.side_effect = add_obj
+    rel_transaction.add.side_effect = add_rel
+
+    mock_openbis.obj_transaction = obj_transaction
+    mock_openbis.rel_transaction = rel_transaction
+
+    # No Object initially uploaded
+    mock_openbis.get_object.return_value = None
+
     # # Create the mock openbis instance
     # openbis = Openbis(url="https://test.openbis.ch")
     # openbis.username = "testuser"


### PR DESCRIPTION
Fixed:
- TypeError: cannot unpack non-iterable NoneType object for parser init by moving the error-handling for missing calls before the init

Changes:
- changed the tests to work with the new function
- added transaction mocks for testing

TODO:
- check if the logic for "test_run_parser_with_object_reference(...)" is outdated or something is missing in run_parser.py
(Line 119-120)

Closes #309 