### PR TITLE
SIMS new object types and vocabularies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 # Owners of individual datamodel directories and its subdirectories
 /bam_masterdata/datamodel/welding/ @CagtayFabry
 /bam_masterdata/datamodel/creep_test/ @MarkusSchilling
-/bam_masterdata/datamodel/mass_spectrometry/ @janlisec @caro-demi
+/bam_masterdata/datamodel/mass_spectrometry/ @janlisec @caro-demi @elisabethjohn

--- a/bam_masterdata/datamodel/mass_spectrometry/object_types.py
+++ b/bam_masterdata/datamodel/mass_spectrometry/object_types.py
@@ -181,6 +181,7 @@ class SIMS(ExperimentalStep):
         generated_code_prefix="EXP.SIMS",
     )
 
+    # TODO check if this property should be moved to the ExperimentalStep type
     customer = PropertyTypeAssignment(
         code="CUSTOMER",
         data_type="VARCHAR",

--- a/bam_masterdata/datamodel/mass_spectrometry/object_types.py
+++ b/bam_masterdata/datamodel/mass_spectrometry/object_types.py
@@ -177,7 +177,7 @@ class GcSystem(Instrument):
 class SIMS(ExperimentalStep):
     defs = ObjectTypeDef(
         code="EXPERIMENTAL_STEP.SIMS",
-        description="""Experimental Step (ToF-SIMS)//Experimenteller Schritt (ToF-SIMS)""",
+        description="""Experimental step for a Time-of-Flight Secondary-Ion-Mass-Spectrometry (ToF-SIMS) analysis in spectrometry, depth profiling or imaging mode//Experimenteller Schritt für eine Time-of-Flight Sekundärionen-Massenspektrometrie (ToF-SIMS) Analyse im Spektrometrie-, Tiefenprofil- oder Imaging-Modus""",
         generated_code_prefix="EXP.SIMS",
     )
 
@@ -221,37 +221,31 @@ class SIMS(ExperimentalStep):
         section="Experimental Settings",
     )
 
-    sims_charge_compensation = PropertyTypeAssignment(
-        code="SIMS_CHARGE_COMPENSATION",
-        data_type="BOOLEAN",
-        property_label="Is there charge compensation?",
-        description="""Is there charge compensation being used?""",
-        mandatory=False,
-        section="Experimental Settings",
-    )
-
     sims_lmig_voltage_dc = PropertyTypeAssignment(
         code="SIMS_LMIG_VOLTAGE_DC",
-        data_type="VARCHAR",
+        data_type="REAL",
+        units="nA",
         property_label="LMIG Voltage DC",
-        description="""LMIG Voltage in nA, direct current (DC)""",
+        description="""LMIG Voltage direct current (DC) in nA""",
         mandatory=False,
         section="Experimental Settings",
     )
 
     sims_lmig_voltage_p = PropertyTypeAssignment(
         code="SIMS_LMIG_VOLTAGE_P",
-        data_type="VARCHAR",
+        data_type="REAL",
+        units="pA",
         property_label="LMIG Voltage P",
-        description="""LMIG Voltage in pA, pulsed (P)""",
+        description="""LMIG Voltage pulsed (P) in pA""",
         mandatory=False,
         section="Experimental Settings",
     )
 
     sims_lmig_pulse_width = PropertyTypeAssignment(
         code="SIMS_LMIG_PULSE_WIDTH",
-        data_type="VARCHAR",
-        property_label="Primary ion beam pulse width [ns]",
+        data_type="REAL",
+        units="ns",
+        property_label="Primary ion beam pulse width",
         description="""Primary ion beam pulse width in ns""",
         mandatory=False,
         section="Experimental Settings",
@@ -259,9 +253,10 @@ class SIMS(ExperimentalStep):
 
     sims_lmig_raster_size = PropertyTypeAssignment(
         code="SIMS_LMIG_RASTER_SIZE",
-        data_type="VARCHAR",
-        property_label="Primary ion beam raster size [µm]",
-        description="""Primary ion beam raster size [µm]""",
+        data_type="REAL",
+        units="µm",
+        property_label="Primary ion beam raster size",
+        description="""Primary ion beam raster size in µm""",
         mandatory=False,
         section="Experimental Settings",
     )
@@ -278,7 +273,8 @@ class SIMS(ExperimentalStep):
 
     sims_dsc_voltage = PropertyTypeAssignment(
         code="SIMS_DSC_VOLTAGE",
-        data_type="VARCHAR",
+        data_type="REAL",
+        units="nA",
         property_label="DSC Voltage",
         description="""DSC Voltage in nA""",
         mandatory=False,
@@ -287,9 +283,20 @@ class SIMS(ExperimentalStep):
 
     sims_dsc_raster_size = PropertyTypeAssignment(
         code="SIMS_DSC_RASTER_SIZE",
-        data_type="VARCHAR",
-        property_label="Secondary ion beam raster size [µm]",
-        description="""Secondary (Sputter) ion beam raster size [µm]""",
+        data_type="REAL",
+        units="µm",
+        property_label="Secondary ion beam raster size",
+        description="""Secondary (Sputter) ion beam raster size in µm""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_charge_compensation = PropertyTypeAssignment(
+        code="SIMS_CHARGE_COMPENSATION",
+        data_type="REAL",
+        units="V",
+        property_label="Charge compensation",
+        description="""Charge compensation in V""",
         mandatory=False,
         section="Experimental Settings",
     )

--- a/bam_masterdata/datamodel/mass_spectrometry/object_types.py
+++ b/bam_masterdata/datamodel/mass_spectrometry/object_types.py
@@ -172,3 +172,123 @@ class GcSystem(Instrument):
         mandatory=False,
         section="Technical Details",
     )
+
+
+class SIMS(ExperimentalStep):
+    defs = ObjectTypeDef(
+        code="EXPERIMENTAL_STEP.SIMS",
+        description="""Experimental Step (ToF-SIMS)//Experimenteller Schritt (ToF-SIMS)""",
+        generated_code_prefix="EXP.SIMS",
+    )
+
+    customer = PropertyTypeAssignment(
+        code="CUSTOMER",
+        data_type="VARCHAR",
+        property_label="Customer",
+        description="""Name of the person for whom the measurement is performed""",
+        mandatory=False,
+        section="General Information",
+    )
+
+    sims_lmig_setting = PropertyTypeAssignment(
+        code="SIMS_LMIG_SETTING",
+        data_type="CONTROLLEDVOCABULARY",
+        vocabulary_code="SIMS_LMIG_SETTING",
+        property_label="LMIG Setting",
+        description="""LMIG setting used for measurement""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_primary_ion = PropertyTypeAssignment(
+        code="SIMS_PRIMARY_ION",
+        data_type="CONTROLLEDVOCABULARY",
+        vocabulary_code="SIMS_PRIMARY_ION",
+        property_label="Primary Ion",
+        description="""Primary ion used for analysis""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_polarity = PropertyTypeAssignment(
+        code="SIMS_POLARITY",
+        data_type="CONTROLLEDVOCABULARY",
+        vocabulary_code="MS_ION_POLARITY",
+        property_label="Polarity",
+        description="""Polarity""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_charge_compensation = PropertyTypeAssignment(
+        code="SIMS_CHARGE_COMPENSATION",
+        data_type="BOOLEAN",
+        property_label="Is there charge compensation?",
+        description="""Is there charge compensation being used?""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_lmig_voltage_dc = PropertyTypeAssignment(
+        code="SIMS_LMIG_VOLTAGE_DC",
+        data_type="VARCHAR",
+        property_label="LMIG Voltage DC",
+        description="""LMIG Voltage in nA, direct current (DC)""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_lmig_voltage_p = PropertyTypeAssignment(
+        code="SIMS_LMIG_VOLTAGE_P",
+        data_type="VARCHAR",
+        property_label="LMIG Voltage P",
+        description="""LMIG Voltage in pA, pulsed (P)""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_lmig_pulse_width = PropertyTypeAssignment(
+        code="SIMS_LMIG_PULSE_WIDTH",
+        data_type="VARCHAR",
+        property_label="Primary ion beam pulse width [ns]",
+        description="""Primary ion beam pulse width in ns""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_lmig_raster_size = PropertyTypeAssignment(
+        code="SIMS_LMIG_RASTER_SIZE",
+        data_type="VARCHAR",
+        property_label="Primary ion beam raster size [µm]",
+        description="""Primary ion beam raster size [µm]""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_sputter_source = PropertyTypeAssignment(
+        code="SIMS_SPUTTER_SOURCE",
+        data_type="CONTROLLEDVOCABULARY",
+        vocabulary_code="SIMS_SPUTTER_SOURCE",
+        property_label="Sputter Source",
+        description="""Sputter Source""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_dsc_voltage = PropertyTypeAssignment(
+        code="SIMS_DSC_VOLTAGE",
+        data_type="VARCHAR",
+        property_label="DSC Voltage",
+        description="""DSC Voltage in nA""",
+        mandatory=False,
+        section="Experimental Settings",
+    )
+
+    sims_dsc_raster_size = PropertyTypeAssignment(
+        code="SIMS_DSC_RASTER_SIZE",
+        data_type="VARCHAR",
+        property_label="Secondary ion beam raster size [µm]",
+        description="""Secondary (Sputter) ion beam raster size [µm]""",
+        mandatory=False,
+        section="Experimental Settings",
+    )

--- a/bam_masterdata/datamodel/mass_spectrometry/vocabularies.py
+++ b/bam_masterdata/datamodel/mass_spectrometry/vocabularies.py
@@ -264,3 +264,120 @@ class MassSpecType(VocabularyType):
         label="Orbitrap",
         description="""Orbitrap//Orbitrap""",
     )
+
+
+class SIMSPrimaryIon(VocabularyType):
+    defs = VocabularyTypeDef(
+        code="SIMS_PRIMARY_ION",
+        description="""Type of Primary Ion""",
+    )
+
+    Bi1 = VocabularyTerm(
+        code="BI1",
+        label="Bi+",
+        description="""Bi+""",
+    )
+
+    Bi2 = VocabularyTerm(
+        code="BI2",
+        label="Bi2+",
+        description="""Bi2+""",
+    )
+
+    Bi3 = VocabularyTerm(
+        code="BI3",
+        label="Bi3+",
+        description="""Bi3+""",
+    )
+
+    Bi4 = VocabularyTerm(
+        code="BI4",
+        label="Bi4+",
+        description="""Bi4+""",
+    )
+
+    Bi5 = VocabularyTerm(
+        code="BI5",
+        label="Bi5+",
+        description="""Bi5+""",
+    )
+
+    Bi6 = VocabularyTerm(
+        code="BI6",
+        label="Bi6+",
+        description="""Bi6+""",
+    )
+
+    Bi7 = VocabularyTerm(
+        code="BI7",
+        label="Bi7+",
+        description="""Bi7+""",
+    )
+
+    Bi1pp = VocabularyTerm(
+        code="BI1PP",
+        label="Bi1++",
+        description="""Bi1++""",
+    )
+
+    Bi3pp = VocabularyTerm(
+        code="BI3PP",
+        label="Bi3++",
+        description="""Bi3++""",
+    )
+
+    Bi5pp = VocabularyTerm(
+        code="BI5PP",
+        label="Bi5++",
+        description="""Bi5++""",
+    )
+
+    Bi7pp = VocabularyTerm(
+        code="BI7PP",
+        label="Bi7++",
+        description="""Bi7++""",
+    )
+
+
+class SIMSLMIGSetting(VocabularyType):
+    defs = VocabularyTypeDef(
+        code="SIMS_LMIG_SETTING",
+        description="""Type of LMIG Setting file""",
+    )
+
+    spectrometry = VocabularyTerm(
+        code="SPECTROMETRY",
+        label="Spectrometry",
+        description="""Spectrometry""",
+    )
+
+    fast_imaging = VocabularyTerm(
+        code="FAST_IMAGING",
+        label="Fast Imaging",
+        description="""Fast Imaging""",
+    )
+
+    ultimate_imaging = VocabularyTerm(
+        code="ULTIMATE_IMAGING",
+        label="Ultimate Imaging+",
+        description="""Ultimate Imaging""",
+    )
+
+
+class SIMSSputterSource(VocabularyType):
+    defs = VocabularyTypeDef(
+        code="SIMS_SPUTTER_SOURCE",
+        description="""Sputter Source used""",
+    )
+
+    oxygen = VocabularyTerm(
+        code="OXYGEN",
+        label="O2",
+        description="""Oxygen""",
+    )
+
+    cesium = VocabularyTerm(
+        code="CESIUM",
+        label="Cs",
+        description="""Cesium""",
+    )


### PR DESCRIPTION
Hi @elisabethjohn,

I've transfered the changes and before merging them into the datamodel. You can see the changes in the "Files changed" tab: https://github.com/BAMresearch/bam-masterdata/pull/320/changes

I have done some minor changes:

- I've fixed the names of `SIMSLMIGSetting` and `SIMSSputterSource` vocabulary terms to match their codes. Before, they were named `Bi1`, `Bi2`, `Bi3` (in the case of SIMSLMIGSetting) or `Positive`, `Negative` (for SIMSSputterSource), I guess from copy-pasting from other vocabulary.
- I have used `MS_ION_POLARITY instead of `SIMSPolarity`
- I've redefined `class ExperimentalStep_SIMS(ObjectType)` to `class SIMS(ExperimentalStep)`. Note that in Python the parenthesis points to inheritance, and as you are defining a subtype of ExperimentalStep, that's encoded by doing so. Furthermore, because you are inheriting, you do not need to copy-paste all the PropertyTypeAssignment that appear again in ExperimentalStep down in SIMS, e.g., name, show_in_project_overview, start_date,..., so you only need to define the properties specific for SIMS
- I've changed the `code` of the SIMS properties to match our current style and make it cleaner
- I've changed the label of `SIMS_CHARGE_COMPENSATION` to reflect better its boolean character

And can you address these small comments/questions:
1. Please, make sure that the order you used in SIMS is the one you want. This reflects how they will appear in the ELN at the end.
2. Right now, all other properties in `SIMS` that are not controlled vocabularies are marked as VARCHAR. They look to me like REAL properties. We can even define their units if so. Is that so?
3. Can you improve the `description` of SIMS a bit please? 🙂 
4. I like your addition of `customer`. I feel this is even more generic than SIMS. For now, I've added a `# TODO` comment so we do not forget to check it later so we can revisit if this property should be instead defined for `ExperimentalStep` and `SIMS`, and all other experimental steps, would inherit it.