### PR TITLE
change to valid pint units or add ToDo

### DIFF
--- a/bam_masterdata/datamodel/activities.py
+++ b/bam_masterdata/datamodel/activities.py
@@ -112,8 +112,8 @@ class Dcpd(ExperimentalStep):
     dcpd_temp_coeff = PropertyTypeAssignment(
         code="DCPD_TEMP_COEFF",
         data_type="REAL",
-        property_label="Temperature Coefficient of Resistivity [°C^-1]",
-        description="""Temperature Coefficient of Resistivity [°C^-1]//Temperaturkoeffizient der Resistivität [°C^-1]""",
+        property_label="Temperature Coefficient of Resistivity [K^-1]",
+        description="""Temperature Coefficient of Resistivity [K^-1]//Temperaturkoeffizient der Resistivität [K^-1]""",
         mandatory=False,
         section="Temperature Compensation",
     )
@@ -746,8 +746,8 @@ class VideoRecording(ExperimentalStep):
     video_frame_per_seconds = PropertyTypeAssignment(
         code="VIDEO_FRAME_PER_SECONDS",
         data_type="INTEGER",
-        property_label="Average video framerate [frames per second]",
-        description="""Average video framerate [frames per second]//Mittlere Bildrate (in Bilder pro Sekunde)""",
+        property_label="Average video framerate [count per second]",
+        description="""Average video framerate [count per second]//Mittlere Bildrate [Bilder pro Sekunde]""",
         mandatory=False,
         section="Video Information",
     )

--- a/bam_masterdata/datamodel/instruments.py
+++ b/bam_masterdata/datamodel/instruments.py
@@ -48,8 +48,8 @@ class ForceTransducer(Instrument):
     calibration_interval = PropertyTypeAssignment(
         code="CALIBRATION_INTERVAL",
         data_type="INTEGER",
-        property_label="Calibration Interval [Months]",
-        description="""Calibration Interval [Months]//Kalibrierintervall [Monate]""",
+        property_label="Calibration Interval [months]",
+        description="""Calibration Interval [months]//Kalibrierintervall [Monate]""",
         mandatory=False,
         section="Status",
     )
@@ -101,8 +101,8 @@ class HydraulicCylinder(Instrument):
     calibration_interval = PropertyTypeAssignment(
         code="CALIBRATION_INTERVAL",
         data_type="INTEGER",
-        property_label="Calibration Interval [Months]",
-        description="""Calibration Interval [Months]//Kalibrierintervall [Monate]""",
+        property_label="Calibration Interval [months]",
+        description="""Calibration Interval [months]//Kalibrierintervall [Monate]""",
         mandatory=False,
         section="Status",
     )
@@ -127,8 +127,8 @@ class HydraulicMisc(Instrument):
     calibration_interval = PropertyTypeAssignment(
         code="CALIBRATION_INTERVAL",
         data_type="INTEGER",
-        property_label="Calibration Interval [Months]",
-        description="""Calibration Interval [Months]//Kalibrierintervall [Monate]""",
+        property_label="Calibration Interval [months]",
+        description="""Calibration Interval [months]//Kalibrierintervall [Monate]""",
         mandatory=False,
         section="Status",
     )
@@ -189,8 +189,8 @@ class Servovalve(Instrument):
     calibration_interval = PropertyTypeAssignment(
         code="CALIBRATION_INTERVAL",
         data_type="INTEGER",
-        property_label="Calibration Interval [Months]",
-        description="""Calibration Interval [Months]//Kalibrierintervall [Monate]""",
+        property_label="Calibration Interval [months]",
+        description="""Calibration Interval [months]//Kalibrierintervall [Monate]""",
         mandatory=False,
         section="Status",
     )
@@ -756,8 +756,8 @@ class MeasuringAmplifier(Instrument):
     calibration_interval = PropertyTypeAssignment(
         code="CALIBRATION_INTERVAL",
         data_type="INTEGER",
-        property_label="Calibration Interval [Months]",
-        description="""Calibration Interval [Months]//Kalibrierintervall [Monate]""",
+        property_label="Calibration Interval [months]",
+        description="""Calibration Interval [months]//Kalibrierintervall [Monate]""",
         mandatory=False,
         section="Status",
     )
@@ -871,7 +871,7 @@ class Centrifuge(Instrument):
     centrifuge_maximum_speed_rcf = PropertyTypeAssignment(
         code="CENTRIFUGE.MAXIMUM_SPEED_RCF",
         data_type="INTEGER",
-        property_label="Maximum Centrifugation Speed (depending on rotor) [rcf]",
+        property_label="Maximum Centrifugation Speed (depending on rotor) [rcf]",  # ToDo: not a valid pint unit
         description="""Maximum Centrifugation Speed (depending on rotor) [rcf]//Maximale Zentrifugationsgeschwindigkeit (rotorabhängig) [rcf]""",
         mandatory=False,
         section="Instrument Specification",
@@ -951,7 +951,7 @@ class CentrifugeRotor(Instrument):
     centrifuge_rotor_maximum_speed_rcf = PropertyTypeAssignment(
         code="CENTRIFUGE_ROTOR.MAXIMUM_SPEED_RCF",
         data_type="INTEGER",
-        property_label="Maximum Speed [rcf]",
+        property_label="Maximum Speed [rcf]",  # ToDo: not a valid pint unit
         description="""Maximum Rotor Speed [rcf]//Maximale Rotor-Geschwindigkeit [rcf]""",
         mandatory=False,
         section="Rotor Specification",
@@ -1317,7 +1317,7 @@ class Lens(Camera):
     lens_aperture_max = PropertyTypeAssignment(
         code="LENS_APERTURE_MAX",
         data_type="REAL",
-        property_label="Maximum Aperture [f/]",
+        property_label="Maximum Aperture [f/]",  # ToDo: not a valid pint unit
         description="""Maximum Aperture [f/]//Maximale Blendenöffnung [f/]""",
         mandatory=False,
         section="Lens Information",
@@ -1326,7 +1326,7 @@ class Lens(Camera):
     lens_aperture_min = PropertyTypeAssignment(
         code="LENS_APERTURE_MIN",
         data_type="REAL",
-        property_label="Minimum Aperture [f/]",
+        property_label="Minimum Aperture [f/]",  # ToDo: not a valid pint unit
         description="""Minimum Aperture [f/]//Minimale Blendenzahl [f/]""",
         mandatory=False,
         section="Lens Information",

--- a/bam_masterdata/datamodel/object_types.py
+++ b/bam_masterdata/datamodel/object_types.py
@@ -5412,8 +5412,8 @@ class MatSimStructure(ObjectType):
     sim_cell_angles_in_deg = PropertyTypeAssignment(
         code="SIM_CELL_ANGLES_IN_DEG",
         data_type="VARCHAR",
-        property_label="Simulation Cell Angles [Degrees]",
-        description="""Simulation cell angles [Degrees]//Winkel der Simulationszelle [Grad]""",
+        property_label="Simulation Cell Angles [degrees]",
+        description="""Simulation cell angles [degrees]//Winkel der Simulationszelle [Grad]""",
         mandatory=False,
         section="Simulation Information",
     )
@@ -5764,8 +5764,8 @@ class Steel(ObjectType):
     raw_mat_amount_in_stock = PropertyTypeAssignment(
         code="RAW_MAT_AMOUNT_IN_STOCK",
         data_type="INTEGER",
-        property_label="Amount in Stock [Pieces]",
-        description="""Amount in Stock [Pieces]//Anzahl auf Lager [Stück]""",
+        property_label="Amount in Stock [count]",
+        description="""Amount in Stock [count]//Anzahl auf Lager [Stück]""",
         mandatory=False,
         section="Stock",
     )
@@ -6103,8 +6103,8 @@ class Aluminium(ObjectType):
     raw_mat_amount_in_stock = PropertyTypeAssignment(
         code="RAW_MAT_AMOUNT_IN_STOCK",
         data_type="INTEGER",
-        property_label="Amount in Stock [Pieces]",
-        description="""Amount in Stock [Pieces]//Anzahl auf Lager [Stück]""",
+        property_label="Amount in Stock [count]",
+        description="""Amount in Stock [count]//Anzahl auf Lager [Stück]""",
         mandatory=False,
         section="Stock",
     )
@@ -8139,8 +8139,8 @@ class Crystal(MatSimStructure):
     lattice_angalpha_in_deg = PropertyTypeAssignment(
         code="LATTICE_ANGALPHA_IN_DEG",
         data_type="REAL",
-        property_label="Lattice Angle (alpha) [Degrees]",
-        description="""Lattice angle (alpha) [Degrees]//Gitterwinkel (alpha) [Grad]""",
+        property_label="Lattice Angle (alpha) [degrees]",
+        description="""Lattice angle (alpha) [degrees]//Gitterwinkel (alpha) [Grad]""",
         mandatory=False,
         section="Material Information",
     )
@@ -8148,8 +8148,8 @@ class Crystal(MatSimStructure):
     lattice_angbeta_in_deg = PropertyTypeAssignment(
         code="LATTICE_ANGBETA_IN_DEG",
         data_type="REAL",
-        property_label="Lattice Angle (beta) [Degrees]",
-        description="""Lattice angle (beta) [Degrees]//Gitterwinkel (beta) [Grad]""",
+        property_label="Lattice Angle (beta) [degrees]",
+        description="""Lattice angle (beta) [degrees]//Gitterwinkel (beta) [Grad]""",
         mandatory=False,
         section="Material Information",
     )
@@ -8157,8 +8157,8 @@ class Crystal(MatSimStructure):
     lattice_anggamma_in_deg = PropertyTypeAssignment(
         code="LATTICE_ANGGAMMA_IN_DEG",
         data_type="REAL",
-        property_label="Lattice Angle (gamma) [Degrees]",
-        description="""Lattice angle (gamma) [Degrees]//Gitterwinkel (gamma) [Grad]""",
+        property_label="Lattice Angle (gamma) [degrees]",
+        description="""Lattice angle (gamma) [degrees]//Gitterwinkel (gamma) [Grad]""",
         mandatory=False,
         section="Material Information",
     )


### PR DESCRIPTION
I was trying a unit extraction script for pint (0.25.3) and noticed a few unit descriptions that are not convertiable to pint.Unit

I adjusted the unit where I could, but some are not defined or I am not sure what they mean (`rcf`)