### PR TITLE
Add TOOL object type for FB 8.2 equipment workflow

### DIFF
--- a/bam_masterdata/datamodel/object_types.py
+++ b/bam_masterdata/datamodel/object_types.py
@@ -1257,7 +1257,7 @@ class Tool(ObjectType):
     defs = ObjectTypeDef(
         code="TOOL",
         description="""Tool//Werkzeug""",
-        generated_code_prefix="S",
+        generated_code_prefix="TOOL",
         auto_generate_codes=False,
     )
 
@@ -1267,7 +1267,7 @@ class Tool(ObjectType):
         property_label="Name",
         description="""Name""",
         mandatory=True,
-        section="General",
+        section="General Information",
     )
 
     description = PropertyTypeAssignment(
@@ -1276,7 +1276,7 @@ class Tool(ObjectType):
         property_label="Description",
         description="""Short description and/or purpose//Kurzbeschreibung und/oder Zweck""",
         mandatory=False,
-        section="General",
+        section="General Information",
     )
 
     manufacturer = PropertyTypeAssignment(
@@ -1285,7 +1285,7 @@ class Tool(ObjectType):
         property_label="Manufacturer",
         description="""Manufacturer//Hersteller""",
         mandatory=False,
-        section="Equipment",
+        section="Equipment Details",
     )
 
     bam_location_complete = PropertyTypeAssignment(
@@ -1295,7 +1295,7 @@ class Tool(ObjectType):
         property_label="Complete BAM Location",
         description="""Complete BAM location (up to room level)//Komplette BAM-Ortsangabe (bis Raumlevel)""",
         mandatory=False,
-        section="Equipment",
+        section="Equipment Details",
     )
 
     bam_oe = PropertyTypeAssignment(
@@ -1305,7 +1305,7 @@ class Tool(ObjectType):
         property_label="BAM Organizational Entity",
         description="""BAM Organizational Entity//BAM Organisationseinheit (OE)""",
         mandatory=False,
-        section="Organisation",
+        section="Equipment Details",
     )
 
     model_name = PropertyTypeAssignment(
@@ -1314,7 +1314,7 @@ class Tool(ObjectType):
         property_label="Model Name",
         description="""Modellbezeichnung//Modellbezeichnung""",
         mandatory=False,
-        section="Equipment",
+        section="Equipment Details",
     )
 
     serial_number = PropertyTypeAssignment(
@@ -1323,7 +1323,7 @@ class Tool(ObjectType):
         property_label="Serial Number",
         description="""Serial Number//Seriennummer""",
         mandatory=True,
-        section="Equipment",
+        section="Equipment Details",
     )
 
     bam_inventory_number = PropertyTypeAssignment(
@@ -1332,7 +1332,7 @@ class Tool(ObjectType):
         property_label="BAM Inventory Number",
         description="""BAM-Inventarnummer//BAM-Inventarnummer""",
         mandatory=False,
-        section="Equipment",
+        section="Equipment Details",
     )
 
     equipment_status = PropertyTypeAssignment(
@@ -1342,7 +1342,7 @@ class Tool(ObjectType):
         property_label="Status",
         description="""Status des Geräts oder Werkzeugs//Status des Geräts oder Werkzeugs""",
         mandatory=True,
-        section="Status",
+        section="Equipment Details",
     )
 
     responsible_person = PropertyTypeAssignment(
@@ -1352,7 +1352,7 @@ class Tool(ObjectType):
         property_label="Responsible person",
         description="""Responsible person//Verantwortliche Person""",
         mandatory=False,
-        section="Responsibility",
+        section="Equipment Details",
     )
 
     calibration_certification = PropertyTypeAssignment(
@@ -1361,7 +1361,7 @@ class Tool(ObjectType):
         property_label="Calibration / Certification",
         description="""Kalibrierung bzw. Zertifizierung//Kalibrierung bzw. Zertifizierung""",
         mandatory=False,
-        section="Calibration",
+        section="Equipment Details",
     )
 
     last_calibration_date = PropertyTypeAssignment(
@@ -1370,17 +1370,17 @@ class Tool(ObjectType):
         property_label="Last Calibration",
         description="""Letzte Kalibrierung//Letzte Kalibrierung""",
         mandatory=False,
-        section="Calibration",
+        section="Equipment Details",
     )
 
-    tool_work_output = PropertyTypeAssignment(
-        code="TOOL_WORK_OUTPUT",
+    tool_purpose = PropertyTypeAssignment(
+        code="TOOL_PURPOSE",
         data_type="CONTROLLEDVOCABULARY",
-        vocabulary_code="TOOL_WORK_OUTPUT",
-        property_label="Work Output",
-        description="""Arbeitsergebnis//Arbeitsergebnis""",
+        vocabulary_code="TOOL_PURPOSE",
+        property_label="Tool Purpose",
+        description="""Tool purpose//Verwendungszweck des Werkzeugs""",
         mandatory=True,
-        section="Classification",
+        section="Equipment Details",
     )
 
 

--- a/bam_masterdata/datamodel/object_types.py
+++ b/bam_masterdata/datamodel/object_types.py
@@ -1253,6 +1253,137 @@ class AuxiliaryMaterial(ObjectType):
     )
 
 
+class Tool(ObjectType):
+    defs = ObjectTypeDef(
+        code="TOOL",
+        description="""Tool//Werkzeug""",
+        generated_code_prefix="S",
+        auto_generate_codes=False,
+    )
+
+    name = PropertyTypeAssignment(
+        code="$NAME",
+        data_type="VARCHAR",
+        property_label="Name",
+        description="""Name""",
+        mandatory=True,
+        section="General",
+    )
+
+    description = PropertyTypeAssignment(
+        code="DESCRIPTION",
+        data_type="MULTILINE_VARCHAR",
+        property_label="Description",
+        description="""Short description and/or purpose//Kurzbeschreibung und/oder Zweck""",
+        mandatory=False,
+        section="General",
+    )
+
+    manufacturer = PropertyTypeAssignment(
+        code="MANUFACTURER",
+        data_type="VARCHAR",
+        property_label="Manufacturer",
+        description="""Manufacturer//Hersteller""",
+        mandatory=False,
+        section="Equipment",
+    )
+
+    bam_location_complete = PropertyTypeAssignment(
+        code="BAM_LOCATION_COMPLETE",
+        data_type="CONTROLLEDVOCABULARY",
+        vocabulary_code="BAM_LOCATION_COMPLETE",
+        property_label="Complete BAM Location",
+        description="""Complete BAM location (up to room level)//Komplette BAM-Ortsangabe (bis Raumlevel)""",
+        mandatory=False,
+        section="Equipment",
+    )
+
+    bam_oe = PropertyTypeAssignment(
+        code="BAM_OE",
+        data_type="CONTROLLEDVOCABULARY",
+        vocabulary_code="BAM_OE",
+        property_label="BAM Organizational Entity",
+        description="""BAM Organizational Entity//BAM Organisationseinheit (OE)""",
+        mandatory=False,
+        section="Organisation",
+    )
+
+    model_name = PropertyTypeAssignment(
+        code="MODEL_NAME",
+        data_type="VARCHAR",
+        property_label="Model Name",
+        description="""Modellbezeichnung//Modellbezeichnung""",
+        mandatory=False,
+        section="Equipment",
+    )
+
+    serial_number = PropertyTypeAssignment(
+        code="SERIAL_NUMBER",
+        data_type="VARCHAR",
+        property_label="Serial Number",
+        description="""Serial Number//Seriennummer""",
+        mandatory=True,
+        section="Equipment",
+    )
+
+    bam_inventory_number = PropertyTypeAssignment(
+        code="BAM_INVENTORY_NUMBER",
+        data_type="VARCHAR",
+        property_label="BAM Inventory Number",
+        description="""BAM-Inventarnummer//BAM-Inventarnummer""",
+        mandatory=False,
+        section="Equipment",
+    )
+
+    equipment_status = PropertyTypeAssignment(
+        code="EQUIPMENT_STATUS",
+        data_type="CONTROLLEDVOCABULARY",
+        vocabulary_code="INSTRUMENT_STATUS",
+        property_label="Status",
+        description="""Status des Geräts oder Werkzeugs//Status des Geräts oder Werkzeugs""",
+        mandatory=True,
+        section="Status",
+    )
+
+    responsible_person = PropertyTypeAssignment(
+        code="RESPONSIBLE_PERSON",
+        data_type="OBJECT",
+        object_code="PERSON.BAM",
+        property_label="Responsible person",
+        description="""Responsible person//Verantwortliche Person""",
+        mandatory=False,
+        section="Responsibility",
+    )
+
+    calibration_certification = PropertyTypeAssignment(
+        code="CALIBRATION_CERTIFICATION",
+        data_type="MULTILINE_VARCHAR",
+        property_label="Calibration / Certification",
+        description="""Kalibrierung bzw. Zertifizierung//Kalibrierung bzw. Zertifizierung""",
+        mandatory=False,
+        section="Calibration",
+    )
+
+    last_calibration_date = PropertyTypeAssignment(
+        code="LAST_CALIBRATION_DATE",
+        data_type="DATE",
+        property_label="Last Calibration",
+        description="""Letzte Kalibrierung//Letzte Kalibrierung""",
+        mandatory=False,
+        section="Calibration",
+    )
+
+    tool_work_output = PropertyTypeAssignment(
+        code="TOOL_WORK_OUTPUT",
+        data_type="CONTROLLEDVOCABULARY",
+        vocabulary_code="TOOL_WORK_OUTPUT",
+        property_label="Work Output",
+        description="""Arbeitsergebnis//Arbeitsergebnis""",
+        mandatory=True,
+        section="Classification",
+    )
+
+
 class Instrument(ObjectType):
     defs = ObjectTypeDef(
         code="INSTRUMENT",

--- a/bam_masterdata/datamodel/vocabulary_types.py
+++ b/bam_masterdata/datamodel/vocabulary_types.py
@@ -32167,3 +32167,28 @@ class SampleOrigin(VocabularyType):
         label="Structure//Bauwerk",
         description="""Structure//Bauwerk""",
     )
+
+
+class ToolWorkOutput(VocabularyType):
+    defs = VocabularyTypeDef(
+        code="TOOL_WORK_OUTPUT",
+        description="""Tool Work Output//Arbeitsergebnis des Werkzeugs""",
+    )
+
+    cut = VocabularyTerm(
+        code="CUT",
+        label="Schneiden",
+        description="""Cutting//Schneiden""",
+    )
+
+    drill = VocabularyTerm(
+        code="DRILL",
+        label="Bohren",
+        description="""Drilling//Bohren""",
+    )
+
+    scan = VocabularyTerm(
+        code="SCAN",
+        label="Scannen",
+        description="""Scanning//Scannen""",
+    )

--- a/bam_masterdata/datamodel/vocabulary_types.py
+++ b/bam_masterdata/datamodel/vocabulary_types.py
@@ -32169,10 +32169,10 @@ class SampleOrigin(VocabularyType):
     )
 
 
-class ToolWorkOutput(VocabularyType):
+class ToolPurpose(VocabularyType):
     defs = VocabularyTypeDef(
-        code="TOOL_WORK_OUTPUT",
-        description="""Tool Work Output//Arbeitsergebnis des Werkzeugs""",
+        code="TOOL_PURPOSE",
+        description="""Tool Purpose//Verwendungszweck des Werkzeugs""",
     )
 
     cut = VocabularyTerm(


### PR DESCRIPTION
Existing equipment types require metadata that does not apply to many tools in the FB 8.2 workflow. This adds a dedicated `TOOL` object type based on the Excel definition prepared for #354.

The 13 properties cover identification, location, responsibility, calibration and tool purpose, grouped into General Information and Equipment Details. Name, serial number, equipment status and tool purpose are mandatory. The code prefix is `TOOL`; automatic code generation is disabled, as in the Excel. `TOOL_PURPOSE` defines `CUT`, `DRILL` and `SCAN`. Existing vocabulary references and the `PERSON.BAM` reference are reused where specified, with shared labels and descriptions aligned with the existing model. No existing type definitions are changed.

The Excel's `MODEL_NAME`, `BAM_INVENTORY_NUMBER` (text) and `EQUIPMENT_STATUS` codes are retained, alongside the calibration fields. The source Excel's `TOOL_WORK_OUTPUT` property and vocabulary are named `TOOL_PURPOSE` in this contribution. Existing development instances using the old code would need a separate migration; this PR only adds schema definitions. `BAM_LOCATION_COMPLETE` remains a reference to the instance-provided vocabulary; no location terms are included.

Validation on Python 3.12:
- Comparison with the source Excel, accounting for the purpose rename, prefix and section changes, and direct `MasterdataChecker` validation in `individual` mode passed.
- `ruff check` and `ruff format --check` passed for both changed files.
- `python -m pytest -q --ignore=tests/cli --ignore=tests/metadata/test_entities_dict.py tests`: 247 passed, 1 skipped.
- The full suite (`python -m pytest -sv tests`) could not collect the CLI tests because of the existing `"Openbis" | None` annotation error in `cli/run_parser.py`. The CLI entry point is affected by the same error, so the model checker was called directly.

Closes #354.
